### PR TITLE
Fix warnings and use stdint types

### DIFF
--- a/GuruxDLMSClientExample/src/communication.cpp
+++ b/GuruxDLMSClientExample/src/communication.cpp
@@ -983,7 +983,7 @@ int CGXCommunication::UpdateFrameCounter()
         {
             m_Parser->GetCiphering()->SetInvocationCounter(1 + d.GetValue().ToInteger());
         }
-        printf("Invocation counter: %li\n", m_Parser->GetCiphering()->GetInvocationCounter());
+        printf("Invocation counter: %u\n", m_Parser->GetCiphering()->GetInvocationCounter());
         reply.Clear();
         Disconnect();
         m_Parser->SetClientAddress(add);

--- a/GuruxDLMSClientExample/src/communication.cpp
+++ b/GuruxDLMSClientExample/src/communication.cpp
@@ -944,7 +944,7 @@ int CGXCommunication::UpdateFrameCounter()
             printf("UpdateFrameCounter\n");
         }
         m_Parser->SetProposedConformance((DLMS_CONFORMANCE)(m_Parser->GetProposedConformance() | DLMS_CONFORMANCE_GENERAL_PROTECTION));
-        unsigned long add = m_Parser->GetClientAddress();
+        uint32_t add = m_Parser->GetClientAddress();
         DLMS_AUTHENTICATION auth = m_Parser->GetAuthentication();
         DLMS_SECURITY security = m_Parser->GetCiphering()->GetSecurity();
         CGXByteBuffer challenge = m_Parser->GetCtoSChallenge();

--- a/GuruxDLMSMeterListener/src/communication.cpp
+++ b/GuruxDLMSMeterListener/src/communication.cpp
@@ -43,7 +43,7 @@ void CGXCommunication::WriteValue(GX_TRACE_LEVEL trace, std::string line)
 {
     if (trace > GX_TRACE_LEVEL_WARNING)
     {
-        printf(line.c_str());
+        printf("%s", line.c_str());
     }
     GXHelpers::Write("LogFile.txt", line);
 }
@@ -294,7 +294,7 @@ int CGXCommunication::UpdateFrameCounter()
             printf("UpdateFrameCounter\n");
         }
         m_Parser->SetProposedConformance((DLMS_CONFORMANCE)(m_Parser->GetProposedConformance() | DLMS_CONFORMANCE_GENERAL_PROTECTION));
-        unsigned long add = m_Parser->GetClientAddress();
+        uint32_t add = m_Parser->GetClientAddress();
         DLMS_AUTHENTICATION auth = m_Parser->GetAuthentication();
         DLMS_SECURITY security = m_Parser->GetCiphering()->GetSecurity();
         CGXByteBuffer challenge = m_Parser->GetCtoSChallenge();
@@ -333,7 +333,7 @@ int CGXCommunication::UpdateFrameCounter()
         {
             m_Parser->GetCiphering()->SetInvocationCounter(1 + d.GetValue().ToInteger());
         }
-        printf("Invocation counter: %d\n", m_Parser->GetCiphering()->GetInvocationCounter());
+        printf("Invocation counter: %lu\n", m_Parser->GetCiphering()->GetInvocationCounter());
         reply.Clear();
         Disconnect();
         m_Parser->SetClientAddress(add);

--- a/GuruxDLMSMeterListener/src/communication.cpp
+++ b/GuruxDLMSMeterListener/src/communication.cpp
@@ -333,7 +333,7 @@ int CGXCommunication::UpdateFrameCounter()
         {
             m_Parser->GetCiphering()->SetInvocationCounter(1 + d.GetValue().ToInteger());
         }
-        printf("Invocation counter: %lu\n", m_Parser->GetCiphering()->GetInvocationCounter());
+        printf("Invocation counter: %u\n", m_Parser->GetCiphering()->GetInvocationCounter());
         reply.Clear();
         Disconnect();
         m_Parser->SetClientAddress(add);

--- a/GuruxDLMSPushExample/src/GXDLMSPushListener.cpp
+++ b/GuruxDLMSPushExample/src/GXDLMSPushListener.cpp
@@ -196,8 +196,8 @@ void ListenerThread(void* pVoid)
                         string xml;
                         CGXDLMSTranslator t(DLMS_TRANSLATOR_OUTPUT_TYPE_SIMPLE_XML);
                         t.DataToXml(notify.GetData(), xml);
-                        printf(xml.c_str());                       
-                        printf("Server address: %d Client Address: %d\r\n", notify.GetServerAddress(), notify.GetClientAddress());
+                        printf("%s", xml.c_str());
+                        printf("Server address: %d Client Address: %u\r\n", notify.GetServerAddress(), notify.GetClientAddress());
                         notify.Clear();
                         bb.SetSize(0);
                     }

--- a/GuruxDLMSPushExample/src/GXDLMSPushListener.cpp
+++ b/GuruxDLMSPushExample/src/GXDLMSPushListener.cpp
@@ -197,7 +197,7 @@ void ListenerThread(void* pVoid)
                         CGXDLMSTranslator t(DLMS_TRANSLATOR_OUTPUT_TYPE_SIMPLE_XML);
                         t.DataToXml(notify.GetData(), xml);
                         printf("%s", xml.c_str());
-                        printf("Server address: %d Client Address: %u\r\n", notify.GetServerAddress(), notify.GetClientAddress());
+                        printf("Server address: %u Client Address: %u\r\n", notify.GetServerAddress(), notify.GetClientAddress());
                         notify.Clear();
                         bb.SetSize(0);
                     }

--- a/GuruxDLMSServerExample/src/GXDLMSBase.cpp
+++ b/GuruxDLMSServerExample/src/GXDLMSBase.cpp
@@ -344,9 +344,9 @@ CGXDLMSData* AddLogicalDeviceName(CGXDLMSObjectCollection& items, unsigned long 
 {
     char buff[17];
 #if defined(_WIN32) || defined(_WIN64)//Windows
-    sprintf_s(buff, "GRX%.13d", sn);
+    sprintf_s(buff, "GRX%.13lu", sn);
 #else
-    sprintf(buff, "GRX%.13d", sn);
+    sprintf(buff, "GRX%.13lu", sn);
 #endif
     CGXDLMSVariant id;
     id.Add((const char*)buff, 16);
@@ -375,9 +375,9 @@ void AddElectricityID1(CGXDLMSObjectCollection& items, unsigned long sn)
 {
     char buff[17];
 #if defined(_WIN32) || defined(_WIN64)//Windows
-    sprintf_s(buff, "GRX%.13d", sn);
+    sprintf_s(buff, "GRX%.13lu", sn);
 #else
-    sprintf(buff, "GRX%.13d", sn);
+    sprintf(buff, "GRX%.13lu", sn);
 #endif
     CGXDLMSVariant id;
     id.Add((const char*)buff, 16);

--- a/development/include/GXCipher.h
+++ b/development/include/GXCipher.h
@@ -39,6 +39,7 @@
 #include "GXPrivateKey.h"
 #include "GXPublicKey.h"
 #include "GXx509Certificate.h"
+#include <cstdint>
 
 class CGXCipher
 {
@@ -69,7 +70,7 @@ private:
     /**
      * Frame counter. AKA Invocation counter.
      */
-    unsigned long m_FrameCounter;
+    uint32_t m_FrameCounter;
 
     DLMS_SECURITY_SUITE m_SecuritySuite;
 
@@ -187,7 +188,7 @@ public:
         DLMS_SECURITY_SUITE suite,
         DLMS_SECURITY security,
         DLMS_COUNT_TYPE type,
-        unsigned long frameCounter,
+        uint32_t frameCounter,
         unsigned char tag,
         CGXByteBuffer& systemTitle,
         CGXByteBuffer& key,
@@ -292,16 +293,16 @@ public:
     /**
      * Returns Frame counter. AKA. Invocation counter.
      */
-    unsigned long GetFrameCounter();
+    uint32_t GetFrameCounter();
 
-    void SetFrameCounter(unsigned long value);
+    void SetFrameCounter(uint32_t value);
 
     /**
      * Returns Invocation counter. AKA Frame counter.
      */
-    unsigned long GetInvocationCounter();
+    uint32_t GetInvocationCounter();
 
-    void SetInvocationCounter(unsigned long value);
+    void SetInvocationCounter(uint32_t value);
 
     void Reset();
 

--- a/development/include/GXDLMSCharge.h
+++ b/development/include/GXDLMSCharge.h
@@ -36,6 +36,7 @@
 #define GXCHARGE_H
 
 #include "GXIgnore.h"
+#include <cstdint>
 #ifndef DLMS_IGNORE_CHARGE
 #include "GXDLMSObject.h"
 #include "GXUnitCharge.h"
@@ -52,7 +53,7 @@ class CGXDLMSCharge : public CGXDLMSObject
     CGXUnitCharge m_UnitChargeActive;
     CGXUnitCharge m_UnitChargePassive;
     CGXDateTime m_UnitChargeActivationTime;
-    unsigned long m_Period;
+    uint32_t m_Period;
     DLMS_CHARGE_CONFIGURATION m_ChargeConfiguration;
     CGXDateTime m_LastCollectionTime;
     long m_LastCollectionAmount;
@@ -191,7 +192,7 @@ public:
      *
      * @return Period.
      */
-    unsigned long GetPeriod()
+    uint32_t GetPeriod()
     {
         return m_Period;
     }
@@ -203,7 +204,7 @@ public:
      * @param value
      *            Period.
      */
-    void SetPeriod(unsigned long value)
+    void SetPeriod(uint32_t value)
     {
         m_Period = value;
     }

--- a/development/include/GXDLMSClient.h
+++ b/development/include/GXDLMSClient.h
@@ -40,6 +40,7 @@
 #include "GXSecure.h"
 #include "GXDateTime.h"
 #include "GXDLMSAccessItem.h"
+#include <cstdint>
 
 class CGXDLMSClient
 {
@@ -190,16 +191,16 @@ public:
     void SetAuthentication(DLMS_AUTHENTICATION value);
 
     // Gets client address.
-    unsigned long GetClientAddress();
+    uint32_t GetClientAddress();
 
     // Sets client address.
-    void SetClientAddress(unsigned long value);
+    void SetClientAddress(uint32_t value);
 
     // Server address.
-    unsigned long GetServerAddress();
+    uint32_t GetServerAddress();
 
     // Server address.
-    void SetServerAddress(unsigned long value);
+    void SetServerAddress(uint32_t value);
 
     // Maximum client PDU size.
     unsigned short GetMaxPduSize();
@@ -980,7 +981,7 @@ public:
      * @return Server address.
      */
     static int GetServerAddressFromSerialNumber(
-        unsigned long serialNumber,
+        uint32_t serialNumber,
         unsigned short logicalAddress,
         const char* formula = NULL);
 
@@ -995,8 +996,8 @@ public:
      *            Address size in bytes.
      * @return Server address.
      */
-    static int  GetServerAddress(unsigned long logicalAddress,
-        unsigned long physicalAddress,
+    static int  GetServerAddress(uint32_t logicalAddress,
+        uint32_t physicalAddress,
         unsigned char addressSize = 0);
 
     /**

--- a/development/include/GXDLMSDemandRegister.h
+++ b/development/include/GXDLMSDemandRegister.h
@@ -36,6 +36,7 @@
 #define GXDLMSDEMANDREGISTER_H
 
 #include "GXIgnore.h"
+#include <cstdint>
 #include "GXDLMSObject.h"
 #ifndef DLMS_IGNORE_DEMAND_REGISTER
 /**
@@ -52,7 +53,7 @@ class CGXDLMSDemandRegister : public CGXDLMSObject
     CGXDateTime m_CaptureTime;
     CGXDateTime m_StartTimeCurrent;
     int m_NumberOfPeriods;
-    unsigned long m_Period;
+    uint32_t m_Period;
 
 protected:
     bool IsRead(int index);
@@ -121,8 +122,8 @@ public:
     CGXDateTime& GetStartTimeCurrent();
     void SetStartTimeCurrent(CGXDateTime& value);
 
-    unsigned long GetPeriod();
-    void SetPeriod(unsigned long value);
+    uint32_t GetPeriod();
+    void SetPeriod(uint32_t value);
 
     int GetNumberOfPeriods();
     void SetNumberOfPeriods(int value);

--- a/development/include/GXDLMSSFSKMacCounters.h
+++ b/development/include/GXDLMSSFSKMacCounters.h
@@ -36,6 +36,7 @@
 #define GXDLMSSFSKMACCOUNTERS_H
 
 #include "GXIgnore.h"
+#include <cstdint>
 #ifndef DLMS_IGNORE_SFSK_MAC_COUNTERS
 #include "GXDLMSObject.h"
 
@@ -93,19 +94,19 @@ public:
     */
     std::vector< std::pair<uint16_t, uint32_t> >& GetSynchronizationRegister();
 
-    long GetPhysicalLayerDesynchronization();
+    uint32_t GetPhysicalLayerDesynchronization();
     void SetPhysicalLayerDesynchronization(uint32_t value);
 
-    long GetTimeOutNotAddressedDesynchronization();
+    uint32_t GetTimeOutNotAddressedDesynchronization();
     void SetTimeOutNotAddressedDesynchronization(uint32_t value);
 
-    long GetTimeOutFrameNotOkDesynchronization();
-    void SetTimeOutFrameNotOkDesynchronization(long value);
+    uint32_t GetTimeOutFrameNotOkDesynchronization();
+    void SetTimeOutFrameNotOkDesynchronization(uint32_t value);
 
-    long GetWriteRequestDesynchronization();
+    uint32_t GetWriteRequestDesynchronization();
     void SetWriteRequestDesynchronization(uint32_t value);
 
-    long GetWrongInitiatorDesynchronization();
+    uint32_t GetWrongInitiatorDesynchronization();
     void SetWrongInitiatorDesynchronization(uint32_t value);
 
     /*

--- a/development/include/GXDLMSSettings.h
+++ b/development/include/GXDLMSSettings.h
@@ -41,6 +41,7 @@
 #include "GXPlcSettings.h"
 #include "GXDLMSObjectCollection.h"
 #include "GXCipher.h"
+#include <cstdint>
 
 // Server sender frame sequence starting number.
 const unsigned char SERVER_START_SENDER_FRAME_SEQUENCE = 0x1E;
@@ -95,12 +96,12 @@ class CGXDLMSSettings
     DLMS_SERVICE_CLASS m_ServiceClass;
 
     // Client address.
-    unsigned long m_ClientAddress;
+    uint32_t m_ClientAddress;
     // Client address.
-    unsigned long m_PushClientAddress;
+    uint32_t m_PushClientAddress;
 
     // Server address.
-    unsigned long m_ServerAddress;
+    uint32_t m_ServerAddress;
 
     // Is Logical Name referencing used.
     bool m_UseLogicalNameReferencing;
@@ -153,7 +154,7 @@ class CGXDLMSSettings
     CGXPlcSettings m_PlcSettings;
 
     // Block packet index.
-    unsigned long m_BlockIndex;
+    uint32_t m_BlockIndex;
 
     // List of server or client objects.
     CGXDLMSObjectCollection m_Objects;
@@ -281,10 +282,10 @@ public:
     unsigned char GetKeepAlive();
 
     // Gets current block index.
-    unsigned long GetBlockIndex();
+    uint32_t GetBlockIndex();
 
     // Sets current block index.
-    void SetBlockIndex(unsigned long value);
+    void SetBlockIndex(uint32_t value);
 
     // Resets block index to default value.
     void ResetBlockIndex();
@@ -308,22 +309,22 @@ public:
     void SetInterfaceType(DLMS_INTERFACE_TYPE value);
 
     // Gets client address.
-    unsigned long GetClientAddress();
+    uint32_t GetClientAddress();
 
     // Sets client address.
-    void SetClientAddress(unsigned long value);
+    void SetClientAddress(uint32_t value);
 
     // Gets push client address.
-    unsigned long GetPushClientAddress();
+    uint32_t GetPushClientAddress();
 
     // Sets push client address.
-    void SetPushClientAddress(unsigned long value);
+    void SetPushClientAddress(uint32_t value);
 
     // Server address.
-    unsigned long GetServerAddress();
+    uint32_t GetServerAddress();
 
     // Server address.
-    void SetServerAddress(unsigned long value);
+    void SetServerAddress(uint32_t value);
 
     // DLMS version number.
     unsigned char GetDLMSVersion();
@@ -374,13 +375,13 @@ public:
     /**
        * @return Invoke ID.
        */
-    unsigned long GetLongInvokeID();
+    uint32_t GetLongInvokeID();
 
     /**
      * @param value
      *            Invoke ID.
      */
-    int SetLongInvokeID(unsigned long value);
+    int SetLongInvokeID(uint32_t value);
 
     // Collection of the objects.
     CGXDLMSObjectCollection& GetObjects();
@@ -504,7 +505,7 @@ public:
     // Expected Invocation(Frame) counter value.
     // Expected Invocation counter is not check if value is zero.
     uint64_t GetExpectedInvocationCounter();
-    void SetExpectedInvocationCounter(uint64_t uint32_t);
+    void SetExpectedInvocationCounter(uint64_t value);
 
     /////////////////////////////////////////////////////////////////////////
     // Expected security policy.

--- a/development/include/GXDLMSTranslator.h
+++ b/development/include/GXDLMSTranslator.h
@@ -143,7 +143,7 @@ public:
     /**
      * Frame counter. AKA Invocation counter.
      */
-    unsigned long m_FrameCounter;
+    uint32_t m_FrameCounter;
 
     /*
     * Get all tags.
@@ -263,9 +263,9 @@ public:
     /**
      * @return Frame counter. Invocation counter.
      */
-    unsigned long GetFrameCounter();
+    uint32_t GetFrameCounter();
 
-    void SetFrameCounter(unsigned long value);
+    void SetFrameCounter(uint32_t value);
 
     // Convert bytes to xml.
     // value: Bytes to convert.

--- a/development/src/GXCipher.cpp
+++ b/development/src/GXCipher.cpp
@@ -36,6 +36,7 @@
 #include "../include/GXCipher.h"
 #include "../include/chipperingenums.h"
 #include "../include/GXHelpers.h"
+#include <cstdint>
 
 void CGXCipher::Init(
     unsigned char* systemTitle,
@@ -88,7 +89,7 @@ CGXCipher::~CGXCipher()
 * @return
 */
 static int GetNonse(
-    unsigned long frameCounter,
+    uint32_t frameCounter,
     CGXByteBuffer& systemTitle,
     CGXByteBuffer& nonce)
 {
@@ -104,10 +105,10 @@ static int GetNonse(
 }
 
 //Get UInt32.
-#define GETU32(pt) (((unsigned long)(pt)[0] << 24) | \
-                    ((unsigned long)(pt)[1] << 16) | \
-                    ((unsigned long)(pt)[2] <<  8) | \
-                    ((unsigned long)(pt)[3]))
+#define GETU32(pt) (((uint32_t)(pt)[0] << 24) | \
+                    ((uint32_t)(pt)[1] << 16) | \
+                    ((uint32_t)(pt)[2] <<  8) | \
+                    ((uint32_t)(pt)[3]))
 
 //Set Int32 as Big Endian value.
 #define PUT32(ct, st) { \
@@ -122,7 +123,7 @@ static const unsigned char Rcon[11] = {
 
 
 //There is only one TE table. Counting is taking little bit longer, but memory is needed less.
-const unsigned long Te0[256] = {
+const uint32_t Te0[256] = {
     0xc66363a5U, 0xf87c7c84U, 0xee777799U, 0xf67b7b8dU,
     0xfff2f20dU, 0xd66b6bbdU, 0xde6f6fb1U, 0x91c5c554U,
     0x60303050U, 0x02010103U, 0xce6767a9U, 0x562b2b7dU,
@@ -189,7 +190,7 @@ const unsigned long Te0[256] = {
     0x7bb0b0cbU, 0xa85454fcU, 0x6dbbbbd6U, 0x2c16163aU,
 };
 
-#define RCON(i) ((unsigned long) Rcon[(i)] << 24)
+#define RCON(i) ((uint32_t) Rcon[(i)] << 24)
 
 #define ROTATE(val, bits) ((val >> bits) | (val << (32 - bits)))
 
@@ -229,8 +230,8 @@ int CGXCipher::Int(uint32_t* rk,
     const unsigned char* cipherKey,
     unsigned short keyBits)
 {
-    unsigned long i;
-    unsigned long temp;
+    uint32_t i;
+    uint32_t temp;
 
     rk[0] = GETU32(cipherKey);
     rk[1] = GETU32(cipherKey + 4);
@@ -288,7 +289,7 @@ void CGXCipher::AesEncrypt(
     const unsigned char* pt,
     unsigned char* ct)
 {
-    unsigned long s0, s1, s2, s3, t0, t1, t2, t3;
+    uint32_t s0, s1, s2, s3, t0, t1, t2, t3;
     int r;
     s0 = GETU32(pt) ^ rk[0];
     s1 = GETU32(pt + 4) ^ rk[1];
@@ -338,7 +339,7 @@ void CGXCipher::Xor(
 
 void CGXCipher::shift_right_block(unsigned char* v)
 {
-    unsigned long val = GETU32(v + 12);
+    uint32_t val = GETU32(v + 12);
     val >>= 1;
     if (v[11] & 0x01)
     {
@@ -441,19 +442,19 @@ void CGXCipher::Init_j0(
     {
         memset(J0, 0, 16);
         GetGHash(H, iv, len, J0);
-        PUT32(tmp, (unsigned long)0);
-        PUT32(tmp + 4, (unsigned long)0);
+        PUT32(tmp, (uint32_t)0);
+        PUT32(tmp + 4, (uint32_t)0);
         //Here is expected that data is newer longger than 32 bit.
         //This is done because microcontrollers show warning here.
-        PUT32(tmp + 8, (unsigned long)0);
-        PUT32(tmp + 12, (unsigned long)(len * 8));
+        PUT32(tmp + 8, (uint32_t)0);
+        PUT32(tmp + 12, (uint32_t)(len * 8));
         GetGHash(H, tmp, sizeof(tmp), J0);
     }
 }
 
 void CGXCipher::Inc32(unsigned char* block)
 {
-    unsigned long val;
+    uint32_t val;
     val = GETU32(block + 16 - 4);
     val++;
     PUT32(block + 16 - 4, val);
@@ -532,10 +533,10 @@ void CGXCipher::AesGcmGhash(const unsigned char* H, const unsigned char* aad, in
     GetGHash(H, crypt, crypt_len, S);
     //Here is expected that data is never longer than 32 bit.
     //This is done because microcontrollers show warning here.
-    PUT32(len_buf, (unsigned long)0);
-    PUT32(len_buf + 4, (unsigned long)(aad_len * 8));
-    PUT32(len_buf + 8, (unsigned long)0);
-    PUT32(len_buf + 12, (unsigned long)(crypt_len * 8));
+    PUT32(len_buf, (uint32_t)0);
+    PUT32(len_buf + 4, (uint32_t)(aad_len * 8));
+    PUT32(len_buf + 8, (uint32_t)0);
+    PUT32(len_buf + 12, (uint32_t)(crypt_len * 8));
     GetGHash(H, len_buf, sizeof(len_buf), S);
 }
 
@@ -543,7 +544,7 @@ int CGXCipher::Encrypt(
     DLMS_SECURITY_SUITE suite,
     DLMS_SECURITY security,
     DLMS_COUNT_TYPE type,
-    unsigned long frameCounter,
+    uint32_t frameCounter,
     unsigned char tag,
     CGXByteBuffer& systemTitle,
     CGXByteBuffer& key,
@@ -784,7 +785,7 @@ int CGXCipher::Decrypt(
         suite,
         security,
         DLMS_COUNT_TYPE_DATA,
-        frameCounter,
+        static_cast<uint32_t>(frameCounter),
         0,
         *pTitle,
         key,
@@ -1069,22 +1070,22 @@ int CGXCipher::SetAuthenticationKey(CGXByteBuffer& value)
     return 0;
 }
 
-unsigned long CGXCipher::GetFrameCounter()
+uint32_t CGXCipher::GetFrameCounter()
 {
     return m_FrameCounter;
 }
 
-void CGXCipher::SetFrameCounter(unsigned long value)
+void CGXCipher::SetFrameCounter(uint32_t value)
 {
     m_FrameCounter = value;
 }
 
-unsigned long CGXCipher::GetInvocationCounter()
+uint32_t CGXCipher::GetInvocationCounter()
 {
     return m_FrameCounter;
 }
 
-void CGXCipher::SetInvocationCounter(unsigned long value)
+void CGXCipher::SetInvocationCounter(uint32_t value)
 {
     m_FrameCounter = value;
 }

--- a/development/src/GXDLMSClient.cpp
+++ b/development/src/GXDLMSClient.cpp
@@ -42,6 +42,7 @@
 #include "../include/GXDLMSLNParameters.h"
 #include "../include/GXDLMSSNParameters.h"
 #include "../include/GXEcdsa.h"
+#include <cstdint>
 
 CGXDLMSClient::CGXDLMSClient(bool UseLogicalNameReferencing,
     int clientAddress,
@@ -222,23 +223,23 @@ void CGXDLMSClient::SetAuthentication(DLMS_AUTHENTICATION value)
 }
 
 
-unsigned long CGXDLMSClient::GetClientAddress()
+uint32_t CGXDLMSClient::GetClientAddress()
 {
     return m_Settings.GetClientAddress();
 }
 
-void CGXDLMSClient::SetClientAddress(unsigned long value)
+void CGXDLMSClient::SetClientAddress(uint32_t value)
 {
     m_Settings.SetClientAddress(value);
 }
 
-unsigned long CGXDLMSClient::GetServerAddress()
+uint32_t CGXDLMSClient::GetServerAddress()
 {
     return m_Settings.GetServerAddress();
 }
 
 // Server address.
-void CGXDLMSClient::SetServerAddress(unsigned long value)
+void CGXDLMSClient::SetServerAddress(uint32_t value)
 {
     m_Settings.SetServerAddress(value);
 }
@@ -2151,7 +2152,7 @@ int CGXDLMSClient::ReadRowsByRange(
 }
 
 int CGXDLMSClient::GetServerAddressFromSerialNumber(
-    unsigned long serialNumber,
+    uint32_t serialNumber,
     unsigned short logicalAddress,
     const char* formula)
 {
@@ -2173,8 +2174,8 @@ int CGXDLMSClient::GetServerAddressFromSerialNumber(
     return value;
 }
 
-int  CGXDLMSClient::GetServerAddress(unsigned long logicalAddress,
-    unsigned long physicalAddress, unsigned char addressSize)
+int  CGXDLMSClient::GetServerAddress(uint32_t logicalAddress,
+    uint32_t physicalAddress, unsigned char addressSize)
 {
     if (addressSize < 4 && physicalAddress < 0x80
         && logicalAddress < 0x80)

--- a/development/src/GXDLMSDemandRegister.cpp
+++ b/development/src/GXDLMSDemandRegister.cpp
@@ -143,12 +143,12 @@ void CGXDLMSDemandRegister::SetStartTimeCurrent(CGXDateTime& value)
     m_StartTimeCurrent = value;
 }
 
-unsigned long CGXDLMSDemandRegister::GetPeriod()
+uint32_t CGXDLMSDemandRegister::GetPeriod()
 {
     return m_Period;
 }
 
-void CGXDLMSDemandRegister::SetPeriod(unsigned long value)
+void CGXDLMSDemandRegister::SetPeriod(uint32_t value)
 {
     m_Period = value;
 }
@@ -496,7 +496,7 @@ int CGXDLMSDemandRegister::SetValue(CGXDLMSSettings& settings, CGXDLMSValueEvent
     }
     else if (e.GetIndex() == 8)
     {
-        SetPeriod(e.GetValue().ulVal);
+        SetPeriod(static_cast<uint32_t>(e.GetValue().ulVal));
     }
     else if (e.GetIndex() == 9)
     {

--- a/development/src/GXDLMSSFSKMacCounters.cpp
+++ b/development/src/GXDLMSSFSKMacCounters.cpp
@@ -68,7 +68,7 @@ std::vector< std::pair<uint16_t, uint32_t> >& CGXDLMSSFSKMacCounters::GetSynchro
     return m_SynchronizationRegister;
 }
 
-long CGXDLMSSFSKMacCounters::GetPhysicalLayerDesynchronization()
+uint32_t CGXDLMSSFSKMacCounters::GetPhysicalLayerDesynchronization()
 {
     return m_PhysicalLayerDesynchronization;
 }
@@ -78,7 +78,7 @@ void CGXDLMSSFSKMacCounters::SetPhysicalLayerDesynchronization(uint32_t value)
     m_PhysicalLayerDesynchronization = value;
 }
 
-long CGXDLMSSFSKMacCounters::GetTimeOutNotAddressedDesynchronization()
+uint32_t CGXDLMSSFSKMacCounters::GetTimeOutNotAddressedDesynchronization()
 {
     return m_TimeOutNotAddressedDesynchronization;
 }
@@ -88,17 +88,17 @@ void CGXDLMSSFSKMacCounters::SetTimeOutNotAddressedDesynchronization(uint32_t va
     m_TimeOutNotAddressedDesynchronization = value;
 }
 
-long CGXDLMSSFSKMacCounters::GetTimeOutFrameNotOkDesynchronization()
+uint32_t CGXDLMSSFSKMacCounters::GetTimeOutFrameNotOkDesynchronization()
 {
     return m_TimeOutFrameNotOkDesynchronization;
 }
 
-void CGXDLMSSFSKMacCounters::SetTimeOutFrameNotOkDesynchronization(long value)
+void CGXDLMSSFSKMacCounters::SetTimeOutFrameNotOkDesynchronization(uint32_t value)
 {
     m_TimeOutFrameNotOkDesynchronization = value;
 }
 
-long CGXDLMSSFSKMacCounters::GetWriteRequestDesynchronization()
+uint32_t CGXDLMSSFSKMacCounters::GetWriteRequestDesynchronization()
 {
     return m_WriteRequestDesynchronization;
 }
@@ -108,7 +108,7 @@ void CGXDLMSSFSKMacCounters::SetWriteRequestDesynchronization(uint32_t value)
     m_WriteRequestDesynchronization = value;
 }
 
-long CGXDLMSSFSKMacCounters::GetWrongInitiatorDesynchronization()
+uint32_t CGXDLMSSFSKMacCounters::GetWrongInitiatorDesynchronization()
 {
     return m_WrongInitiatorDesynchronization;
 }

--- a/development/src/GXDLMSSettings.cpp
+++ b/development/src/GXDLMSSettings.cpp
@@ -240,12 +240,12 @@ unsigned char CGXDLMSSettings::GetKeepAlive()
     return (unsigned char)(m_SenderFrame & 0xF1);
 }
 
-unsigned long CGXDLMSSettings::GetBlockIndex()
+uint32_t CGXDLMSSettings::GetBlockIndex()
 {
     return m_BlockIndex;
 }
 
-void CGXDLMSSettings::SetBlockIndex(unsigned long value)
+void CGXDLMSSettings::SetBlockIndex(uint32_t value)
 {
     m_BlockIndex = value;
 }
@@ -286,33 +286,33 @@ void CGXDLMSSettings::SetInterfaceType(DLMS_INTERFACE_TYPE value)
     m_InterfaceType = value;
 }
 
-unsigned long CGXDLMSSettings::GetClientAddress()
+uint32_t CGXDLMSSettings::GetClientAddress()
 {
     return m_ClientAddress;
 }
 
-void CGXDLMSSettings::SetClientAddress(unsigned long value)
+void CGXDLMSSettings::SetClientAddress(uint32_t value)
 {
     m_ClientAddress = value;
 }
 
-unsigned long CGXDLMSSettings::GetPushClientAddress()
+uint32_t CGXDLMSSettings::GetPushClientAddress()
 {
     return m_PushClientAddress;
 }
 
-void CGXDLMSSettings::SetPushClientAddress(unsigned long value)
+void CGXDLMSSettings::SetPushClientAddress(uint32_t value)
 {
     m_PushClientAddress = value;
 }
 
-unsigned long CGXDLMSSettings::GetServerAddress()
+uint32_t CGXDLMSSettings::GetServerAddress()
 {
     return m_ServerAddress;
 }
 
 // Server address.
-void CGXDLMSSettings::SetServerAddress(unsigned long value)
+void CGXDLMSSettings::SetServerAddress(uint32_t value)
 {
     m_ServerAddress = value;
 }
@@ -420,11 +420,11 @@ void CGXDLMSSettings::UpdateInvokeId(unsigned char value) {
 }
 
 
-unsigned long CGXDLMSSettings::GetLongInvokeID()
+uint32_t CGXDLMSSettings::GetLongInvokeID()
 {
     return m_LongInvokeID;
 }
-int CGXDLMSSettings::SetLongInvokeID(unsigned long value)
+int CGXDLMSSettings::SetLongInvokeID(uint32_t value)
 {
     if (value > 0xFFFFFF)
     {

--- a/development/src/GXDLMSTranslator.cpp
+++ b/development/src/GXDLMSTranslator.cpp
@@ -181,12 +181,12 @@ void CGXDLMSTranslator::SetAuthenticationKey(CGXByteBuffer& value)
     m_AuthenticationKey.Set(value.GetData(), value.GetSize() - value.GetPosition());
 }
 
-unsigned long CGXDLMSTranslator::GetFrameCounter()
+uint32_t CGXDLMSTranslator::GetFrameCounter()
 {
     return m_FrameCounter;
 }
 
-void CGXDLMSTranslator::SetFrameCounter(unsigned long value)
+void CGXDLMSTranslator::SetFrameCounter(uint32_t value)
 {
     m_FrameCounter = value;
 }

--- a/mbed/GuruxDLMSClientExample/communication.cpp
+++ b/mbed/GuruxDLMSClientExample/communication.cpp
@@ -49,7 +49,7 @@ void CGXCommunication::WriteValue(GX_TRACE_LEVEL trace, std::string line)
 {
     if (trace > GX_TRACE_LEVEL_WARNING)
     {
-        printf(line.c_str());
+        printf("%s", line.c_str());
     }
 }
 


### PR DESCRIPTION
## Summary
- replace platform dependent `long` with explicit width types in more classes
- update cipher and settings classes to use `uint32_t` counters and addresses
- adjust examples and clients for updated interfaces

## Testing
- `cmake ..`
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_686986aba040832d9a9ff5d32e079520