### PR TITLE
Add missing cstring include

### DIFF
--- a/development/tests/test_gxbytebuffer.cpp
+++ b/development/tests/test_gxbytebuffer.cpp
@@ -1,4 +1,5 @@
 #include "gtest/gtest.h"
+#include <cstring>
 #include "GXBytebuffer.h" // Assuming this is the correct path relative to include dirs
 #include "GXDLMSVariant.h" // For AddString/GetString if they use it, or for general utility
 


### PR DESCRIPTION
## Summary
- include `<cstring>` in `test_gxbytebuffer.cpp`

## Testing
- `cmake ..` *(fails: unable to access googletest repository)*

------
https://chatgpt.com/codex/tasks/task_e_686a2bcffde8832dab51f0b35981e4e8