### PR TITLE
Harden GXByteArray capacity management

### DIFF
--- a/development/include/GXByteArray.h
+++ b/development/include/GXByteArray.h
@@ -51,6 +51,7 @@ class CGXByteArray
     unsigned char* m_Data;
     unsigned long m_Capacity;
     unsigned long m_Size;
+    int EnsureCapacity(unsigned long required);
 public:
     //Constructor.
     CGXByteArray();


### PR DESCRIPTION
## Summary
- add a private capacity helper and grow-on-demand logic that keeps CGXByteArray state consistent on allocation failure paths
- harden indexed writes, zero-fill, and append helpers to guard against overflow, update size correctly, and respect requested string lengths
- improve ToArray and buffer copy helpers to handle allocation failure and propagate errors from buffer sources

## Testing
- cppcheck --enable=warning,style,performance --std=c++11 --language=c++ --inline-suppr development/include/GXByteArray.h development/src/GXByteArray.cpp
- clang-format --dry-run development/include/GXByteArray.h development/src/GXByteArray.cpp
- make -j$(nproc)

------
https://chatgpt.com/codex/tasks/task_e_68dadc7aa440832daef0484afc71527c