### PR TITLE
Add indexed getters for multi-byte values in GXByteBuffer

### DIFF
--- a/development/src/GXBytebuffer.cpp
+++ b/development/src/GXBytebuffer.cpp
@@ -454,18 +454,32 @@ int CGXByteBuffer::GetUInt24(unsigned int *value) {
 }
 
 int CGXByteBuffer::GetUInt32(uint32_t *value) {
-	if (value == nullptr) {
-		return DLMS_ERROR_CODE_INVALID_PARAMETER;
-	}
+        if (value == nullptr) {
+                return DLMS_ERROR_CODE_INVALID_PARAMETER;
+        }
 
-	if (m_Position + 4 > m_Data.size()) {
-		return DLMS_ERROR_CODE_OUTOFMEMORY;
-	}
+        if (m_Position + 4 > m_Data.size()) {
+                return DLMS_ERROR_CODE_OUTOFMEMORY;
+        }
 
-	*value = (static_cast<uint32_t>(m_Data[m_Position]) << 24) | (static_cast<uint32_t>(m_Data[m_Position + 1]) << 16) |
-	    (static_cast<uint32_t>(m_Data[m_Position + 2]) << 8) | static_cast<uint32_t>(m_Data[m_Position + 3]);
-	m_Position += 4;
-	return 0;
+        *value = (static_cast<uint32_t>(m_Data[m_Position]) << 24) | (static_cast<uint32_t>(m_Data[m_Position + 1]) << 16) |
+            (static_cast<uint32_t>(m_Data[m_Position + 2]) << 8) | static_cast<uint32_t>(m_Data[m_Position + 3]);
+        m_Position += 4;
+        return 0;
+}
+
+int CGXByteBuffer::GetUInt32(uint32_t index, uint32_t *value) {
+        if (value == nullptr) {
+                return DLMS_ERROR_CODE_INVALID_PARAMETER;
+        }
+
+        if (index + 4 > m_Data.size()) {
+                return DLMS_ERROR_CODE_OUTOFMEMORY;
+        }
+
+        *value = (static_cast<uint32_t>(m_Data[index]) << 24) | (static_cast<uint32_t>(m_Data[index + 1]) << 16) |
+            (static_cast<uint32_t>(m_Data[index + 2]) << 8) | static_cast<uint32_t>(m_Data[index + 3]);
+        return 0;
 }
 
 int CGXByteBuffer::GetInt8(char *value) {
@@ -514,20 +528,49 @@ int CGXByteBuffer::GetInt64(int64_t *value) {
 }
 
 int CGXByteBuffer::GetUInt64(uint64_t *value) {
-	if (value == nullptr) {
-		return DLMS_ERROR_CODE_INVALID_PARAMETER;
-	}
+        if (value == nullptr) {
+                return DLMS_ERROR_CODE_INVALID_PARAMETER;
+        }
 
 	if (m_Position + 8 > m_Data.size()) {
 		return DLMS_ERROR_CODE_OUTOFMEMORY;
 	}
 
-	*value = (static_cast<uint64_t>(m_Data[m_Position]) << 56) | (static_cast<uint64_t>(m_Data[m_Position + 1]) << 48) |
-	    (static_cast<uint64_t>(m_Data[m_Position + 2]) << 40) | (static_cast<uint64_t>(m_Data[m_Position + 3]) << 32) |
-	    (static_cast<uint64_t>(m_Data[m_Position + 4]) << 24) | (static_cast<uint64_t>(m_Data[m_Position + 5]) << 16) |
-	    (static_cast<uint64_t>(m_Data[m_Position + 6]) << 8) | static_cast<uint64_t>(m_Data[m_Position + 7]);
-	m_Position += 8;
-	return 0;
+        *value = (static_cast<uint64_t>(m_Data[m_Position]) << 56) | (static_cast<uint64_t>(m_Data[m_Position + 1]) << 48) |
+            (static_cast<uint64_t>(m_Data[m_Position + 2]) << 40) | (static_cast<uint64_t>(m_Data[m_Position + 3]) << 32) |
+            (static_cast<uint64_t>(m_Data[m_Position + 4]) << 24) | (static_cast<uint64_t>(m_Data[m_Position + 5]) << 16) |
+            (static_cast<uint64_t>(m_Data[m_Position + 6]) << 8) | static_cast<uint64_t>(m_Data[m_Position + 7]);
+        m_Position += 8;
+        return 0;
+}
+
+int CGXByteBuffer::GetUInt64(uint32_t index, uint64_t *value) {
+        if (value == nullptr) {
+                return DLMS_ERROR_CODE_INVALID_PARAMETER;
+        }
+
+        if (index + 8 > m_Data.size()) {
+                return DLMS_ERROR_CODE_OUTOFMEMORY;
+        }
+
+        *value = (static_cast<uint64_t>(m_Data[index]) << 56) | (static_cast<uint64_t>(m_Data[index + 1]) << 48) |
+            (static_cast<uint64_t>(m_Data[index + 2]) << 40) | (static_cast<uint64_t>(m_Data[index + 3]) << 32) |
+            (static_cast<uint64_t>(m_Data[index + 4]) << 24) | (static_cast<uint64_t>(m_Data[index + 5]) << 16) |
+            (static_cast<uint64_t>(m_Data[index + 6]) << 8) | static_cast<uint64_t>(m_Data[index + 7]);
+        return 0;
+}
+
+int CGXByteBuffer::GetUInt128(uint32_t index, uint8_t *value) {
+        if (value == nullptr) {
+                return DLMS_ERROR_CODE_INVALID_PARAMETER;
+        }
+
+        if (index + 16 > m_Data.size()) {
+                return DLMS_ERROR_CODE_OUTOFMEMORY;
+        }
+
+        std::copy(m_Data.begin() + index, m_Data.begin() + index + 16, value);
+        return 0;
 }
 
 int CGXByteBuffer::GetFloat(float *value) {

--- a/tests/GXByteBufferTest.cpp
+++ b/tests/GXByteBufferTest.cpp
@@ -100,6 +100,34 @@ TEST_F(GXByteBufferTest, DataRetrieval) {
     EXPECT_EQ(0x789ABCDE, u32);
 }
 
+TEST_F(GXByteBufferTest, IndexedMultiByteGetters) {
+    CGXByteBuffer buffer;
+    buffer.SetUInt32(0x11223344);
+    buffer.SetUInt64(0x5566778899AABBCCULL);
+
+    const uint8_t pattern[16] = {
+        0xDE, 0xAD, 0xBE, 0xEF,
+        0xCA, 0xFE, 0xBA, 0xBE,
+        0x12, 0x34, 0x56, 0x78,
+        0x9A, 0xBC, 0xDE, 0xF0
+    };
+    buffer.Set(pattern, sizeof(pattern));
+
+    uint32_t u32 = 0;
+    EXPECT_EQ(0, buffer.GetUInt32(0, &u32));
+    EXPECT_EQ(0x11223344u, u32);
+
+    uint64_t u64 = 0;
+    EXPECT_EQ(0, buffer.GetUInt64(4, &u64));
+    EXPECT_EQ(0x5566778899AABBCCULL, u64);
+
+    uint8_t u128[16] = {};
+    EXPECT_EQ(0, buffer.GetUInt128(12, u128));
+    for (size_t i = 0; i < sizeof(pattern); ++i) {
+        EXPECT_EQ(pattern[i], u128[i]);
+    }
+}
+
 TEST_F(GXByteBufferTest, PositionManagement) {
     CGXByteBuffer buffer;
     buffer.SetUInt8(0x12);


### PR DESCRIPTION
## Summary
- add indexed UInt32/UInt64/UInt128 getters with proper validation and big-endian decoding
- cover the new APIs with tests that verify decoding of known byte patterns

## Testing
- cmake -S . -B build *(fails: string no output variable specified)*

------
https://chatgpt.com/codex/tasks/task_e_68fd0e513484832dba3363acc7c619f8