### PR TITLE
Fix Base64 decoder chunk handling and add regression test

### DIFF
--- a/development/src/GXBytebuffer.cpp
+++ b/development/src/GXBytebuffer.cpp
@@ -928,14 +928,19 @@ int CGXByteBuffer::FromBase64(std::string &input) {
 	}
 	std::string inChars;
 	int b[4];
-	for (pos = 0; pos != input.length(); pos += 4) {
-		inChars = input.substr(pos, pos + 4);
-		b[0] = GetIndex(inChars[0]);
-		b[1] = GetIndex(inChars[1]);
-		b[2] = GetIndex(inChars[2]);
-		b[3] = GetIndex(inChars[3]);
-		SetUInt8((b[0] << 2) | (b[1] >> 4));
-		if (b[2] < 64) {
+        for (pos = 0; pos != input.length(); pos += 4) {
+                inChars = input.substr(pos, 4);
+                b[0] = GetIndex(inChars[0]);
+                b[1] = GetIndex(inChars[1]);
+                b[2] = GetIndex(inChars[2]);
+                b[3] = GetIndex(inChars[3]);
+                for (int idx = 0; idx < 4; ++idx) {
+                        if (b[idx] == -1) {
+                                return DLMS_ERROR_CODE_INVALID_PARAMETER;
+                        }
+                }
+                SetUInt8((b[0] << 2) | (b[1] >> 4));
+                if (b[2] < 64) {
 			SetUInt8((b[1] << 4) | (b[2] >> 2));
 			if (b[3] < 64) {
 				SetUInt8((b[2] << 6) | b[3]);

--- a/tests/GXByteBufferTest.cpp
+++ b/tests/GXByteBufferTest.cpp
@@ -224,8 +224,8 @@ TEST_F(GXByteBufferTest, ClearAndReset) {
 // Test Base64 operations
 TEST_F(GXByteBufferTest, BoundaryConditions) {
     CGXByteBuffer buffer;
-    
-    
+
+
     unsigned char val;
     EXPECT_EQ(DLMS_ERROR_CODE_OUTOFMEMORY, buffer.GetUInt8(&val));
 
@@ -233,6 +233,20 @@ TEST_F(GXByteBufferTest, BoundaryConditions) {
     EXPECT_EQ(0, buffer.SetUInt8(0, 0x12));
     EXPECT_EQ(0, buffer.GetUInt8(0, &val));
     EXPECT_EQ(0x12, val);
+}
+
+TEST_F(GXByteBufferTest, FromBase64MultiBlockDecoding) {
+    std::string base64 =
+        "TWFuIGlzIGRpc3Rpbmd1aXNoZWQsIG5vdCBv\nbmx5IGJ5IGhpcyByZWFzb24=";
+    std::string expected = "Man is distinguished, not only by his reason";
+
+    CGXByteBuffer buffer;
+    EXPECT_EQ(0, buffer.FromBase64(base64));
+    EXPECT_EQ(expected.size(), buffer.GetSize());
+
+    std::string decoded(reinterpret_cast<const char *>(buffer.GetData()),
+                        buffer.GetSize());
+    EXPECT_EQ(expected, decoded);
 }
 
 TEST_F(GXByteBufferTest, SwapOperation) {


### PR DESCRIPTION
## Summary
- ensure CGXByteBuffer::FromBase64 slices four-character blocks and rejects invalid symbols
- add a regression test that decodes a multi-block Base64 payload

## Testing
- cmake --build build --target gurux_tests -j1 > build.log 2>&1
- ./build/bin/gurux_tests
- cmake --build build --target doc

------
https://chatgpt.com/codex/tasks/task_e_68fd17ad7d8c832d993efb415ec8c6f8