### PR TITLE
Reserve base64 decode capacity before decoding

### DIFF
--- a/development/src/GXBytebuffer.cpp
+++ b/development/src/GXBytebuffer.cpp
@@ -942,11 +942,14 @@ int CGXByteBuffer::FromBase64(std::string &input) {
 	if (input.length() % 4 != 0) {
 		return DLMS_ERROR_CODE_INVALID_PARAMETER;
 	}
-	size_t len = (input.length() * 3) / 4;
-	size_t pos = input.find('=', 0);
-	if (pos > 0) {
-		len -= input.length() - pos;
-	}
+        size_t len = (input.length() * 3) / 4;
+        size_t pos = input.find('=', 0);
+        if (pos != std::string::npos) {
+                len -= input.length() - pos;
+        }
+        if (len > 0) {
+                m_Data.reserve(m_Data.size() + len);
+        }
 	std::string inChars;
 	int b[4];
         for (pos = 0; pos != input.length(); pos += 4) {

--- a/tests/GXByteBufferTest.cpp
+++ b/tests/GXByteBufferTest.cpp
@@ -279,6 +279,7 @@ TEST_F(GXByteBufferTest, FromBase64MultiBlockDecoding) {
     CGXByteBuffer buffer;
     EXPECT_EQ(0, buffer.FromBase64(base64));
     EXPECT_EQ(expected.size(), buffer.GetSize());
+    EXPECT_GE(buffer.Capacity(), expected.size());
 
     std::string decoded(reinterpret_cast<const char *>(buffer.GetData()),
                         buffer.GetSize());


### PR DESCRIPTION
## Summary
- reserve the byte buffer capacity up front in FromBase64 so the predicted decode length is used and remove the unused variable warning
- ensure the base64 decoding test verifies that the buffer capacity matches the expected decoded size

## Testing
- cmake --build build --target gurux_tests -j4 *(fails: build currently too heavy to finish in the container time limits)*


------
https://chatgpt.com/codex/tasks/task_e_68fd23043100832db55533ab5a824d77