### PR TITLE
Fix INT8/UINT8 byte serialization and add regression tests

### DIFF
--- a/development/src/GXDLMSVariant.cpp
+++ b/development/src/GXDLMSVariant.cpp
@@ -1514,7 +1514,7 @@ int CGXDLMSVariant::GetBytes(CGXByteBuffer& value)
     }
     else if (vt == DLMS_DATA_TYPE_UINT8)
     {
-        value.SetUInt8(cVal);
+        value.SetUInt8(bVal);
     }
     else if (vt == DLMS_DATA_TYPE_UINT16)
     {
@@ -1530,7 +1530,7 @@ int CGXDLMSVariant::GetBytes(CGXByteBuffer& value)
     }
     else if (vt == DLMS_DATA_TYPE_INT8)
     {
-        value.SetInt8(bVal);
+        value.SetInt8(cVal);
     }
     else if (vt == DLMS_DATA_TYPE_INT16)
     {

--- a/tests/GXDLMSVariantTest.cpp
+++ b/tests/GXDLMSVariantTest.cpp
@@ -1,4 +1,5 @@
 #include <climits>
+#include <cstdint>
 #include <gtest/gtest.h>
 
 #include "GXBytebuffer.h"
@@ -25,4 +26,29 @@ TEST(CGXDLMSVariantTest, WideStringToUtf8Conversion) {
     ASSERT_EQ(expected.size(), buffer.GetSize());
     std::string bytes(reinterpret_cast<const char*>(buffer.GetData()), buffer.GetSize());
     EXPECT_EQ(expected, bytes);
+}
+
+TEST(CGXDLMSVariantTest, Int8SerializationPreservesBitPattern) {
+    const char original = static_cast<char>(-1);
+    CGXDLMSVariant variant(original);
+
+    CGXByteBuffer buffer;
+    ASSERT_EQ(0, variant.GetBytes(buffer));
+    ASSERT_EQ(1u, buffer.GetSize());
+
+    const uint8_t expected = static_cast<uint8_t>(original);
+    ASSERT_NE(nullptr, buffer.GetData());
+    EXPECT_EQ(expected, buffer.GetData()[0]);
+}
+
+TEST(CGXDLMSVariantTest, UInt8SerializationPreservesBitPattern) {
+    const unsigned char original = static_cast<unsigned char>(0xFE);
+    CGXDLMSVariant variant(original);
+
+    CGXByteBuffer buffer;
+    ASSERT_EQ(0, variant.GetBytes(buffer));
+    ASSERT_EQ(1u, buffer.GetSize());
+
+    ASSERT_NE(nullptr, buffer.GetData());
+    EXPECT_EQ(original, buffer.GetData()[0]);
 }


### PR DESCRIPTION
## Summary
- correct the UINT8 and INT8 branches in `CGXDLMSVariant::GetBytes` so the stored value type matches the emitted byte
- add regression tests that serialize a negative INT8 and a high-bit UINT8 and confirm the raw byte written to the buffer

## Testing
- `cmake --build build --target lint` *(fails: repository has pre-existing clang-format violations outside the touched files)*
- `cmake --build build --target doc` *(completes with warnings about missing Graphviz and undocumented parameters)*


------
https://chatgpt.com/codex/tasks/task_e_68fde5f0c680832d8453b1b5ea0f2c96