### PR TITLE
Fix GCTR tag length and expand cipher authentication test

### DIFF
--- a/development/src/GXCipher.cpp
+++ b/development/src/GXCipher.cpp
@@ -489,7 +489,7 @@ int CGXCipher::Encrypt(
             }
             tagOutput = input.GetData() + tagOffset;
         }
-        Gctr(aes, J0, S, sizeof(S), tagOutput);
+        Gctr(aes, J0, S, kTagLength, tagOutput);
         if (!encrypt && memcmp(nonse.GetData(), tagOutput, kTagLength) != 0) {
             ret = DLMS_ERROR_CODE_INVALID_TAG;
         }
@@ -518,12 +518,12 @@ int CGXCipher::Encrypt(
             }
             tagOutput = input.GetData() + tagOffset;
         }
-        Gctr(aes, J0, S, sizeof(S), tagOutput);
+        Gctr(aes, J0, S, kTagLength, tagOutput);
         if (!encrypt) {
             //Decrypt the data.
             AesGcmGctr(aes, J0, input.GetData() + input.GetPosition(), input.Available(), NULL);
         }
-        Gctr(aes, J0, S, sizeof(S), tagOutput);
+        Gctr(aes, J0, S, kTagLength, tagOutput);
         if (!encrypt && memcmp(nonse.GetData(), tagOutput, kTagLength) != 0) {
             ret = DLMS_ERROR_CODE_INVALID_TAG;
         }

--- a/tests/GXCipherTest.cpp
+++ b/tests/GXCipherTest.cpp
@@ -6,6 +6,7 @@ namespace {
 
 TEST(CGXCipherTest, DecryptReturnsInvalidTagWhenAuthenticationTagCorrupted) {
     const unsigned char kSystemTitle[8] = {0x4C, 0x47, 0x58, 0x5F, 0x54, 0x49, 0x54, 0x4C};
+    const size_t kTagLength = 12;
 
     CGXByteBuffer systemTitle;
     ASSERT_EQ(0, systemTitle.Set(kSystemTitle, sizeof(kSystemTitle)));
@@ -16,11 +17,16 @@ TEST(CGXCipherTest, DecryptReturnsInvalidTagWhenAuthenticationTagCorrupted) {
     const unsigned char kPlaintext[] = {0x01, 0x02, 0x03, 0x04};
     CGXByteBuffer encrypted;
     ASSERT_EQ(0, encrypted.Set(kPlaintext, sizeof(kPlaintext)));
+    const size_t originalSize = encrypted.GetSize();
 
     const unsigned long frameCounter = 1;
     ASSERT_EQ(
         0, cipher.Encrypt(DLMS_SECURITY_SUITE_V0, DLMS_SECURITY_AUTHENTICATION, DLMS_COUNT_TYPE_DATA, frameCounter, 0, systemTitle, blockKey, encrypted, true)
     );
+
+    const size_t kHeaderLength = 1 + cipher.GetAuthenticationKey().GetSize();
+    const size_t headerAndPayload = originalSize + kHeaderLength;
+    ASSERT_EQ(kTagLength, encrypted.GetSize() - headerAndPayload);
 
     CGXByteBuffer tampered = encrypted;
     ASSERT_GT(tampered.GetSize(), 0u);


### PR DESCRIPTION
## Summary
- ensure authentication tag generation limits GCTR output to kTagLength so the buffer is not overrun
- extend the cipher authentication test to check tag growth and continue to assert invalid-tag errors on tampered frames

## Testing
- cmake --build build --parallel $(nproc)
- ctest --output-on-failure
- cmake --build build --target doc *(emits dot-not-found warnings in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fe043ce2a4832d9245c14578bea6b0