### PR TITLE
Qualify standard library usage in listener examples

### DIFF
--- a/GuruxDLMSMeterListener/src/GXDLMSMeterListener.cpp
+++ b/GuruxDLMSMeterListener/src/GXDLMSMeterListener.cpp
@@ -54,12 +54,12 @@
 #include <errno.h>
 #endif
 
+#include <string>
+
 #include "../include/communication.h"
 #include "../include/GXDLMSMeterListener.h"
 #include "../../development/include/GXDLMSData.h"
 #include "../../development/include/GXDLMSTranslator.h"
-
-using namespace std;
 
 void ListenerThread(void* pVoid)
 {
@@ -78,7 +78,7 @@ void ListenerThread(void* pVoid)
     struct sockaddr_in client;
     memset(&client, 0, sizeof(client));
     //Get buffer data
-    basic_string<char> senderInfo;
+    std::string senderInfo;
 
     /**
     * Received data. This is used if GBT is used and data is received on

--- a/GuruxDLMSPushExample/src/GXDLMSPushListener.cpp
+++ b/GuruxDLMSPushExample/src/GXDLMSPushListener.cpp
@@ -54,12 +54,13 @@
 #include <errno.h>
 #endif
 
+#include <string>
+#include <vector>
+
 #include "../include/GXDLMSPushListener.h"
 #include "../../development/include/GXDLMSData.h"
 #include "../../development/include/GXDLMSTranslator.h"
 #include "../../development/include/GXDLMSClock.h"
-
-using namespace std;
 
 void ListenerThread(void* pVoid)
 {
@@ -83,7 +84,7 @@ void ListenerThread(void* pVoid)
     struct sockaddr_in client;
     memset(&client, 0, sizeof(client));
     //Get buffer data
-    basic_string<char> senderInfo;
+    std::string senderInfo;
 
     /**
     * Received data. This is used if GBT is used and data is received on
@@ -193,7 +194,7 @@ void ListenerThread(void* pVoid)
                             result.clear();
                         }
                         //Show data as XML.
-                        string xml;
+                        std::string xml;
                         CGXDLMSTranslator t(DLMS_TRANSLATOR_OUTPUT_TYPE_SIMPLE_XML);
                         t.DataToXml(notify.GetData(), xml);
                         printf(xml.c_str());                       

--- a/GuruxDLMSServerExample/src/GXDLMSBase.cpp
+++ b/GuruxDLMSServerExample/src/GXDLMSBase.cpp
@@ -56,6 +56,11 @@
 #include <netdb.h>
 #endif
 
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
 #include "../include/GXDLMSBase.h"
 
 #include "../../development/include/GXTime.h"
@@ -86,7 +91,6 @@
 #include "../../development/include/GXDLMSScriptTable.h"
 #include "../../development/include/GXDLMSSchedule.h"
 
-using namespace std;
 #if defined(_WIN32) || defined(_WIN64)//Windows
 TCHAR DATAFILE[FILENAME_MAX];
 char IMAGEFILE[FILENAME_MAX];
@@ -117,7 +121,7 @@ void ListenerThread(void* pVoid)
     struct sockaddr_in client;
     memset(&client, 0, sizeof(client));
     //Get buffer data
-    basic_string<char> senderInfo;
+    std::string senderInfo;
     while (server->IsConnected())
     {
         len = sizeof(client);
@@ -485,7 +489,7 @@ void AddRegisterMonitor(CGXDLMSObjectCollection& items, CGXDLMSRegister* pRegist
 {
     CGXDLMSRegisterMonitor* pRm = new CGXDLMSRegisterMonitor("0.0.16.1.0.255");
     CGXDLMSVariant threshold;
-    vector<CGXDLMSVariant> thresholds;
+    std::vector<CGXDLMSVariant> thresholds;
     threshold.Add("Gurux1", 6);
     thresholds.push_back(threshold);
     threshold.Clear();
@@ -496,7 +500,7 @@ void AddRegisterMonitor(CGXDLMSObjectCollection& items, CGXDLMSRegister* pRegist
     mv.Update(pRegister, 2);
     pRm->SetMonitoredValue(mv);
     CGXDLMSActionSet* action = new CGXDLMSActionSet();
-    string ln;
+    std::string ln;
     pRm->GetLogicalName(ln);
     action->GetActionDown().SetLogicalName(ln);
     action->GetActionDown().SetScriptSelector(1);
@@ -526,7 +530,7 @@ void AddActionSchedule(CGXDLMSObjectCollection& items)
 void AddSapAssignment(CGXDLMSObjectCollection& items)
 {
     CGXDLMSSapAssignment* pSap = new CGXDLMSSapAssignment();
-    std::map<int, basic_string<char> > list;
+    std::map<int, std::string> list;
     list[1] = "Gurux";
     list[16] = "Gurux-2";
     pSap->SetSapAssignmentList(list);
@@ -556,7 +560,7 @@ void AddModemConfiguration(CGXDLMSObjectCollection& items)
     CGXDLMSModemConfiguration* pMc = new CGXDLMSModemConfiguration();
     pMc->SetCommunicationSpeed(DLMS_BAUD_RATE_38400);
     CGXDLMSModemInitialisation init;
-    vector<CGXDLMSModemInitialisation> initialisationStrings;
+    std::vector<CGXDLMSModemInitialisation> initialisationStrings;
     init.SetRequest("AT");
     init.SetResponse("OK");
     init.SetDelay(0);


### PR DESCRIPTION
## Summary
- remove global `using namespace std;` from the push listener, meter listener, and server example sources
- add the required standard-library headers and qualify `std::string`, `std::vector`, and `std::map` usages explicitly to avoid accidental namespace pollution

## Testing
- `g++ -std=c++11 -Idevelopment/include -IGuruxDLMSPushExample/include -c GuruxDLMSPushExample/src/GXDLMSPushListener.cpp -o /tmp/GXDLMSPushListener.o` *(passes with existing warning about printf format string)*
- `g++ -std=c++11 -Idevelopment/include -IGuruxDLMSMeterListener/include -c GuruxDLMSMeterListener/src/GXDLMSMeterListener.cpp -o /tmp/GXDLMSMeterListener.o`
- `g++ -std=c++11 -Idevelopment/include -IGuruxDLMSServerExample/include -c GuruxDLMSServerExample/src/GXDLMSBase.cpp -o /tmp/GXDLMSBase.o` *(passes with existing sprintf warnings)*
- `bash agents/lint_agent.sh` *(fails: pre-existing clang-format violation in development/src/GXDLMSLNCommandHandler.cpp)*
- `cmake --build build --target test -- -j2` *(fails: gurux_tests_NOT_BUILT target missing executable)*
- `bash agents/doc_agent.sh`


------
https://chatgpt.com/codex/tasks/task_e_68fe07184568832da21b4fb54c6b18cd