### PR TITLE
Handle boolean and enum variant serialization

### DIFF
--- a/development/src/GXDLMSVariant.cpp
+++ b/development/src/GXDLMSVariant.cpp
@@ -1275,6 +1275,10 @@ double CGXDLMSVariant::ToDouble() {
 int CGXDLMSVariant::GetBytes(CGXByteBuffer &value) {
     if (vt == DLMS_DATA_TYPE_OCTET_STRING) {
         value.Set(byteArr, size);
+    } else if (vt == DLMS_DATA_TYPE_BOOLEAN) {
+        value.SetUInt8(boolVal ? 1 : 0);
+    } else if (vt == DLMS_DATA_TYPE_ENUM) {
+        value.SetUInt8(bVal);
     } else if (vt == DLMS_DATA_TYPE_UINT8) {
         value.SetUInt8(bVal);
     } else if (vt == DLMS_DATA_TYPE_UINT16) {

--- a/tests/GXDLMSVariantTest.cpp
+++ b/tests/GXDLMSVariantTest.cpp
@@ -52,3 +52,27 @@ TEST(CGXDLMSVariantTest, UInt8SerializationPreservesBitPattern) {
     ASSERT_NE(nullptr, buffer.GetData());
     EXPECT_EQ(original, buffer.GetData()[0]);
 }
+
+TEST(CGXDLMSVariantTest, BooleanSerializationUsesSingleByte) {
+    CGXDLMSVariant variant(true);
+
+    CGXByteBuffer buffer;
+    ASSERT_EQ(0, variant.GetBytes(buffer));
+    ASSERT_EQ(1u, buffer.GetSize());
+
+    ASSERT_NE(nullptr, buffer.GetData());
+    EXPECT_EQ(1u, buffer.GetData()[0]);
+}
+
+TEST(CGXDLMSVariantTest, EnumSerializationUsesStoredByte) {
+    const unsigned char enumValue = 0x42;
+    CGXDLMSVariant variant(enumValue);
+    ASSERT_EQ(0, variant.ChangeType(DLMS_DATA_TYPE_ENUM));
+
+    CGXByteBuffer buffer;
+    ASSERT_EQ(0, variant.GetBytes(buffer));
+    ASSERT_EQ(1u, buffer.GetSize());
+
+    ASSERT_NE(nullptr, buffer.GetData());
+    EXPECT_EQ(enumValue, buffer.GetData()[0]);
+}


### PR DESCRIPTION
## Summary
- ensure `CGXDLMSVariant::GetBytes` encodes boolean values as 0/1 and enum values using the stored byte
- add unit tests covering boolean and enum serialization of `CGXDLMSVariant`

## Testing
- cmake --build build --parallel $(nproc)
- ctest --output-on-failure
- cmake --build build --target doc

------
https://chatgpt.com/codex/tasks/task_e_68fe07363ca0832d882b6dae0ca60057