### PR TITLE
Guard protocol version length in GenerateApplicationContextName

### DIFF
--- a/development/src/GXAPDU.cpp
+++ b/development/src/GXAPDU.cpp
@@ -37,6 +37,8 @@
 #include "../include/TranslatorStandardTags.h"
 #include "../include/GXDLMSConverter.h"
 
+#include <cstring>
+
 /**
  * Retrieves the string that indicates the level of authentication, if any.
  */
@@ -84,9 +86,13 @@ int CGXAPDU::GenerateApplicationContextName(CGXDLMSSettings &settings, CGXByteBu
     CGXCipher *activeCipher = cipher != NULL ? cipher : settingsCipher;
     //ProtocolVersion
     if (settings.GetProtocolVersion() != NULL) {
+        size_t protocolVersionLength = strlen(settings.GetProtocolVersion());
+        if (protocolVersionLength > 8) {
+            return DLMS_ERROR_CODE_INVALID_PARAMETER;
+        }
         data.SetUInt8(BER_TYPE_CONTEXT | PDU_TYPE_PROTOCOL_VERSION);
         data.SetUInt8(2);
-        data.SetUInt8((unsigned char)(8 - strlen(settings.GetProtocolVersion())));
+        data.SetUInt8((unsigned char)(8 - protocolVersionLength));
         CGXDLMSVariant tmp = settings.GetProtocolVersion();
         GXHelpers::SetBitString(data, tmp, false);
     }

--- a/tests/GXAPDUTest.cpp
+++ b/tests/GXAPDUTest.cpp
@@ -1,7 +1,9 @@
 #include <algorithm>
 #include <gtest/gtest.h>
 
+#define private public
 #include "../development/include/GXAPDU.h"
+#undef private
 
 // Regression test for handling missing cipher configurations when user ID is set.
 TEST(CGXAPDUTest, GenerateAarqWithoutCipherDoesNotCrash) {
@@ -13,6 +15,17 @@ TEST(CGXAPDUTest, GenerateAarqWithoutCipherDoesNotCrash) {
     int ret = CGXAPDU::GenerateAarq(settings, nullptr, nullptr, data);
 
     EXPECT_TRUE(ret == 0 || ret == DLMS_ERROR_CODE_INVALID_PARAMETER);
+}
+
+TEST(CGXAPDUTest, GenerateApplicationContextNameRejectsLongProtocolVersion) {
+    CGXDLMSSettings settings(false);
+    settings.SetProtocolVersion("111111111");
+
+    CGXByteBuffer data;
+    int ret = CGXAPDU::GenerateApplicationContextName(settings, data, nullptr);
+
+    EXPECT_EQ(DLMS_ERROR_CODE_INVALID_PARAMETER, ret);
+    EXPECT_EQ(0u, data.GetSize());
 }
 
 // Verify that GenerateAARE encodes lengths larger than 255 bytes correctly.


### PR DESCRIPTION
## Summary
- reject protocol version strings longer than eight bits when generating the application context name to avoid encoding invalid lengths
- add a unit test confirming GenerateApplicationContextName returns DLMS_ERROR_CODE_INVALID_PARAMETER for nine-bit protocol versions

## Testing
- cmake --build build --parallel $(nproc)
- ctest --output-on-failure
- cmake --build . --target doc
- cmake --build build --target lint *(fails: clang-format check reports pre-existing style violations in development/src/GXDLMSLNCommandHandler.cpp)*

------
https://chatgpt.com/codex/tasks/task_e_68fe25713564832d95ed66d45d33748a