### PR TITLE
Remove duplicate test main from GXByteBufferTest

### DIFF
--- a/tests/GXByteBufferTest.cpp
+++ b/tests/GXByteBufferTest.cpp
@@ -350,8 +350,3 @@ TEST_F(GXByteBufferTest, HexStringOperations) {
     // Format might vary based on GXHelpers implementation
     EXPECT_FALSE(hexWithSpaces.empty());
 }
-
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-}


### PR DESCRIPTION
## Summary
- remove the standalone main function from GXByteBufferTest so GoogleTest's default entry point is used

## Testing
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS=-w -DCMAKE_CXX_FLAGS=-w
- cmake --build build --config Debug
- cd build && ctest --output-on-failure
- cmake --build build --target doc

------
https://chatgpt.com/codex/tasks/task_e_68fe472eeca8832d829c6f95f5909bd4