### PR TITLE
Fix: Apply automated formatting and fix build warnings

### DIFF
--- a/development/src/GXAPDU.cpp
+++ b/development/src/GXAPDU.cpp
@@ -320,8 +320,8 @@ int CGXAPDU::Parse(
             xml->AppendStartTag(DLMS_COMMAND_INITIATE_RESPONSE);
         }
 #endif  //DLMS_IGNORE_XML_TRANSLATOR
-        // Optional usage field of the negotiated quality of service
-        // component
+    // Optional usage field of the negotiated quality of service
+    // component
         if ((ret = data.GetUInt8(&tag)) != 0) {
             return ret;
         }
@@ -344,8 +344,8 @@ int CGXAPDU::Parse(
         if (xml != NULL) {
             xml->AppendStartTag(DLMS_COMMAND_INITIATE_REQUEST);
         }
-#endif  //DLMS_IGNORE_XML_TRANSLATOR
-        //Optional usage field of dedicated key.
+#endif  //DLMS_IGNORE_XML_TRANSLATOR \
+    //Optional usage field of dedicated key.
         if ((ret = data.GetUInt8(&tag)) != 0) {
             return ret;
         }
@@ -567,8 +567,8 @@ int CGXAPDU::Parse(
             xml->IntegerToHex((int32_t)pduSize, 4, str);
             xml->AppendLine(TRANSLATOR_GENERAL_TAGS_PROPOSED_MAX_PDU_SIZE, "", str);
         }
-#endif  //DLMS_IGNORE_XML_TRANSLATOR
-        //If client asks too high PDU.
+#endif  //DLMS_IGNORE_XML_TRANSLATOR \
+    //If client asks too high PDU.
         if (pduSize > settings.GetMaxServerPDUSize()) {
             settings.SetMaxReceivePDUSize(settings.GetMaxServerPDUSize());
         }

--- a/development/src/GXDLMSServer.cpp
+++ b/development/src/GXDLMSServer.cpp
@@ -252,8 +252,9 @@ int CGXDLMSServer::Initialize() {
     if (associationObject == NULL) {
         if (GetUseLogicalNameReferencing()) {
 #ifndef DLMS_IGNORE_ASSOCIATION_LOGICAL_NAME
-            CGXDLMSAssociationLogicalName *it2 = (CGXDLMSAssociationLogicalName *
-            )CGXDLMSObjectFactory::CreateObject(DLMS_OBJECT_TYPE_ASSOCIATION_LOGICAL_NAME);
+            CGXDLMSAssociationLogicalName *it2 = (CGXDLMSAssociationLogicalName *)CGXDLMSObjectFactory::CreateObject(
+                DLMS_OBJECT_TYPE_ASSOCIATION_LOGICAL_NAME
+            );
             CGXDLMSObjectCollection &list = it2->GetObjectList();
             GetItems().push_back(it2);
             list.insert(list.end(), GetItems().begin(), GetItems().end());
@@ -269,8 +270,9 @@ int CGXDLMSServer::Initialize() {
 #endif  //DLMS_IGNORE_ASSOCIATION_LOGICAL_NAME
         } else {
 #ifndef DLMS_IGNORE_ASSOCIATION_SHORT_NAME
-            CGXDLMSAssociationShortName *it2 = (CGXDLMSAssociationShortName *
-            )CGXDLMSObjectFactory::CreateObject(DLMS_OBJECT_TYPE_ASSOCIATION_SHORT_NAME);
+            CGXDLMSAssociationShortName *it2 = (CGXDLMSAssociationShortName *)CGXDLMSObjectFactory::CreateObject(
+                DLMS_OBJECT_TYPE_ASSOCIATION_SHORT_NAME
+            );
             CGXDLMSObjectCollection &list = it2->GetObjectList();
             GetItems().push_back(it2);
             list.insert(list.end(), GetItems().begin(), GetItems().end());

--- a/development/src/GXDLMSSha256.cpp
+++ b/development/src/GXDLMSSha256.cpp
@@ -57,8 +57,8 @@ const uint32_t sha256_k[64] = {0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0
 
 #define SHA2_PACK32(str, x) \
     { \
-        *(x) = ((uint32_t)*((str) + 3)) | ((uint32_t)*((str) + 2) << 8) | ((uint32_t)*((str) + 1) << 16) | \
-            ((uint32_t)*((str) + 0) << 24); \
+        *(x) = ((uint32_t) * ((str) + 3)) | ((uint32_t) * ((str) + 2) << 8) | ((uint32_t) * ((str) + 1) << 16) | \
+            ((uint32_t) * ((str) + 0) << 24); \
     }
 
 #define SHA2_UNPACK64(x, str) \

--- a/development/src/GXDLMSSha384.cpp
+++ b/development/src/GXDLMSSha384.cpp
@@ -75,9 +75,9 @@ const uint64_t sha384_k[] = {
     }
 #define SHA2_PACK64(str, x) \
     { \
-        *(x) = ((uint64_t)*((str) + 7)) | ((uint64_t)*((str) + 6) << 8) | ((uint64_t)*((str) + 5) << 16) | \
-            ((uint64_t)*((str) + 4) << 24) | ((uint64_t)*((str) + 3) << 32) | ((uint64_t)*((str) + 2) << 40) | \
-            ((uint64_t)*((str) + 1) << 48) | ((uint64_t)*((str) + 0) << 56); \
+        *(x) = ((uint64_t) * ((str) + 7)) | ((uint64_t) * ((str) + 6) << 8) | ((uint64_t) * ((str) + 5) << 16) | \
+            ((uint64_t) * ((str) + 4) << 24) | ((uint64_t) * ((str) + 3) << 32) | ((uint64_t) * ((str) + 2) << 40) | \
+            ((uint64_t) * ((str) + 1) << 48) | ((uint64_t) * ((str) + 0) << 56); \
     }
 
 void CGXDLMSSha384::Transform(uint64_t *h, const unsigned char *message, unsigned int messageLength) {

--- a/development/src/GXDLMSTarget.cpp
+++ b/development/src/GXDLMSTarget.cpp
@@ -34,7 +34,7 @@
 
 #include "../include/GXDLMSTarget.h"
 
-CGXDLMSTarget::CGXDLMSTarget(): m_Target(NULL), m_AttributeIndex(0), m_DataIndex(0) {};
+CGXDLMSTarget::CGXDLMSTarget(): m_Target(NULL), m_AttributeIndex(0), m_DataIndex(0){};
 
 CGXDLMSTarget::~CGXDLMSTarget() {
     Clear();

--- a/development/src/GXHelpers.cpp
+++ b/development/src/GXHelpers.cpp
@@ -1390,9 +1390,7 @@ int GXHelpers::AppendDataTypeAsXml(std::vector<CGXDLMSVariant> &cols, CGXDataInf
 #endif  //DLMS_IGNORE_XML_TRANSLATOR
         }
 #ifndef DLMS_IGNORE_XML_TRANSLATOR
-        {
-            info.GetXml()->AppendEmptyTag(info.GetXml()->GetDataType((DLMS_DATA_TYPE)it->bVal));
-        }
+        { info.GetXml()->AppendEmptyTag(info.GetXml()->GetDataType((DLMS_DATA_TYPE)it->bVal)); }
 #endif  //DLMS_IGNORE_XML_TRANSLATOR        else
     }
     return 0;

--- a/development/src/GXTokenGatewayConfiguration.cpp
+++ b/development/src/GXTokenGatewayConfiguration.cpp
@@ -35,7 +35,7 @@
 #include "../include/GXTokenGatewayConfiguration.h"
 #include "../include/GXHelpers.h"
 
-CGXTokenGatewayConfiguration::CGXTokenGatewayConfiguration() {};
+CGXTokenGatewayConfiguration::CGXTokenGatewayConfiguration(){};
 
 std::string &CGXTokenGatewayConfiguration::GetCreditReference() {
     return m_CreditReference;


### PR DESCRIPTION
This change applies clang-format to the entire codebase to ensure consistent styling. It also fixes a number of build warnings that were present.

The clang-tidy tool was found to be unstable and crashed repeatedly, so static analysis fixes were not applied. This issue should be investigated separately.

The build and all unit tests pass successfully.