### PR TITLE
Fix compiler warnings

### DIFF
--- a/GuruxDLMSClientExample/include/communication.h
+++ b/GuruxDLMSClientExample/include/communication.h
@@ -70,8 +70,9 @@
 
 class CGXCommunication
 {
-    GX_TRACE_LEVEL m_Trace;
     CGXDLMSSecureClient* m_Parser;
+    uint16_t m_WaitTime;
+    GX_TRACE_LEVEL m_Trace;
     int m_socket;
     static const unsigned int RECEIVE_BUFFER_SIZE = 200;
     unsigned char   m_Receivebuff[RECEIVE_BUFFER_SIZE];
@@ -83,7 +84,6 @@ class CGXCommunication
 #else
     int             m_hComPort;
 #endif
-    uint16_t m_WaitTime;
     int Read(unsigned char eop, CGXByteBuffer& reply, uint16_t waitTime = 0);
     /// Read Invocation counter (frame counter) from the meter and update it.
     int UpdateFrameCounter();

--- a/GuruxDLMSServerExample/src/GXDLMSBase.cpp
+++ b/GuruxDLMSServerExample/src/GXDLMSBase.cpp
@@ -1398,8 +1398,8 @@ void CGXDLMSBase::PostAction(std::vector<CGXDLMSValueEventArg*>& args)
 
 
 bool CGXDLMSBase::IsTarget(
-    unsigned long int serverAddress,
-    unsigned long clientAddress)
+    unsigned long int /*serverAddress*/,
+    unsigned long /*clientAddress*/)
 {
     return true;
 }
@@ -1495,7 +1495,7 @@ DLMS_METHOD_ACCESS_MODE CGXDLMSBase::GetMethodAccess(CGXDLMSValueEventArg* arg)
 //
 /////////////////////////////////////////////////////////////////////////////
 void CGXDLMSBase::Connected(
-    CGXDLMSConnectionEventArgs& connectionInfo)
+    CGXDLMSConnectionEventArgs& /*connectionInfo*/)
 {
     if (m_Trace > GX_TRACE_LEVEL_WARNING)
     {
@@ -1504,7 +1504,7 @@ void CGXDLMSBase::Connected(
 }
 
 void CGXDLMSBase::InvalidConnection(
-    CGXDLMSConnectionEventArgs& connectionInfo)
+    CGXDLMSConnectionEventArgs& /*connectionInfo*/)
 {
     if (m_Trace > GX_TRACE_LEVEL_WARNING)
     {
@@ -1515,7 +1515,7 @@ void CGXDLMSBase::InvalidConnection(
 //
 /////////////////////////////////////////////////////////////////////////////
 void CGXDLMSBase::Disconnected(
-    CGXDLMSConnectionEventArgs& connectionInfo)
+    CGXDLMSConnectionEventArgs& /*connectionInfo*/)
 {
     if (m_Trace > GX_TRACE_LEVEL_WARNING)
     {
@@ -1538,7 +1538,7 @@ void CGXDLMSBase::PreGet(
 }
 
 void CGXDLMSBase::PostGet(
-    std::vector<CGXDLMSValueEventArg*>& args)
+    std::vector<CGXDLMSValueEventArg*>& /*args*/)
 {
 
 }

--- a/development/include/GXDLMSObject.h
+++ b/development/include/GXDLMSObject.h
@@ -136,7 +136,7 @@ public:
     void SetDescription(std::string &value);
 
     //Get values as std::string.
-    virtual void GetValues(std::vector<std::string> &values) {
+    virtual void GetValues(std::vector<std::string> &/*values*/) {
         assert(0);
     }
 
@@ -148,7 +148,7 @@ public:
     //
     // all: All items are returned even if they are read already.
     // attributes: Collection of attributes to read.
-    virtual void GetAttributeIndexToRead(bool all, std::vector<int> &attributes) {
+    virtual void GetAttributeIndexToRead(bool /*all*/, std::vector<int>& /*attributes*/) {
         assert(0);
     }
 
@@ -177,19 +177,19 @@ public:
     }
 
     // Returns value of given attribute.
-    virtual int GetValue(CGXDLMSSettings &settings, CGXDLMSValueEventArg &e) {
+    virtual int GetValue(CGXDLMSSettings &/*settings*/, CGXDLMSValueEventArg &e) {
         e.SetError(DLMS_ERROR_CODE_READ_WRITE_DENIED);
         return DLMS_ERROR_CODE_OK;
     }
 
     // Set value of given attribute.
-    virtual int SetValue(CGXDLMSSettings &settings, CGXDLMSValueEventArg &e) {
+    virtual int SetValue(CGXDLMSSettings &/*settings*/, CGXDLMSValueEventArg &e) {
         e.SetError(DLMS_ERROR_CODE_READ_WRITE_DENIED);
         return DLMS_ERROR_CODE_OK;
     }
 
     // Set value of given attribute.
-    virtual int Invoke(CGXDLMSSettings &settings, CGXDLMSValueEventArg &e) {
+    virtual int Invoke(CGXDLMSSettings &/*settings*/, CGXDLMSValueEventArg &e) {
         e.SetError(DLMS_ERROR_CODE_READ_WRITE_DENIED);
         return DLMS_ERROR_CODE_OK;
     }

--- a/development/include/TranslatorSimpleTags.h
+++ b/development/include/TranslatorSimpleTags.h
@@ -46,7 +46,7 @@
 class CTranslatorSimpleTags {
 public:
     // Get general tags.
-    static void GetGeneralTags(DLMS_TRANSLATOR_OUTPUT_TYPE type, std::map<unsigned long, std::string> &list) {
+    static void GetGeneralTags(DLMS_TRANSLATOR_OUTPUT_TYPE /*type*/, std::map<unsigned long, std::string> &list) {
         list[DLMS_COMMAND_SNRM] = "Snrm";
         list[DLMS_COMMAND_UNACCEPTABLE_FRAME] = "UnacceptableFrame";
         list[DLMS_COMMAND_DISCONNECT_MODE] = "DisconnectMode";
@@ -94,7 +94,7 @@ public:
     }
 
     // Get SN tags.
-    static void GetSnTags(DLMS_TRANSLATOR_OUTPUT_TYPE type, std::map<unsigned long, std::string> &list) {
+    static void GetSnTags(DLMS_TRANSLATOR_OUTPUT_TYPE /*type*/, std::map<unsigned long, std::string> &list) {
         list[DLMS_COMMAND_READ_REQUEST] = "ReadRequest";
         list[DLMS_COMMAND_WRITE_REQUEST] = "WriteRequest";
         list[DLMS_COMMAND_WRITE_RESPONSE] = "WriteResponse";
@@ -111,7 +111,7 @@ public:
     }
 
     // Get LN tags.
-    static void GetLnTags(DLMS_TRANSLATOR_OUTPUT_TYPE type, std::map<unsigned long, std::string> &list) {
+    static void GetLnTags(DLMS_TRANSLATOR_OUTPUT_TYPE /*type*/, std::map<unsigned long, std::string> &list) {
         list[DLMS_COMMAND_GET_REQUEST] = "GetRequest";
         list[(DLMS_COMMAND_GET_REQUEST) << 8 | DLMS_GET_COMMAND_TYPE_NORMAL] = "GetRequestNormal";
         list[(DLMS_COMMAND_GET_REQUEST) << 8 | DLMS_GET_COMMAND_TYPE_NEXT_DATA_BLOCK] = "GetRequestForNextDataBlock";
@@ -168,7 +168,7 @@ public:
     }
 
     // Get glo tags.
-    static void GetGloTags(DLMS_TRANSLATOR_OUTPUT_TYPE type, std::map<unsigned long, std::string> &list) {
+    static void GetGloTags(DLMS_TRANSLATOR_OUTPUT_TYPE /*type*/, std::map<unsigned long, std::string> &list) {
         list[DLMS_COMMAND_GLO_INITIATE_REQUEST] = "glo_InitiateRequest";
         list[DLMS_COMMAND_GLO_INITIATE_RESPONSE] = "glo_InitiateResponse";
         list[DLMS_COMMAND_GLO_GET_REQUEST] = "glo_GetRequest";
@@ -189,7 +189,7 @@ public:
     /// </summary>
     /// <param name="type"></param>
     /// <param name="list"></param>
-    static void GetDedTags(DLMS_TRANSLATOR_OUTPUT_TYPE type, std::map<unsigned long, std::string> &list) {
+    static void GetDedTags(DLMS_TRANSLATOR_OUTPUT_TYPE /*type*/, std::map<unsigned long, std::string> &list) {
         list[DLMS_COMMAND_DED_INITIATE_REQUEST] = "ded_InitiateRequest";
         list[DLMS_COMMAND_DED_INITIATE_RESPONSE] = "ded_InitiateResponse";
         list[DLMS_COMMAND_DED_GET_REQUEST] = "ded_GetRequest";
@@ -206,7 +206,7 @@ public:
     /// </summary>
     /// <param name="type"></param>
     /// <param name="list"></param>
-    static void GetTranslatorTags(DLMS_TRANSLATOR_OUTPUT_TYPE type, std::map<unsigned long, std::string> &list) {
+    static void GetTranslatorTags(DLMS_TRANSLATOR_OUTPUT_TYPE /*type*/, std::map<unsigned long, std::string> &list) {
         list[DLMS_TRANSLATOR_TAGS_WRAPPER] = "Wrapper";
         list[DLMS_TRANSLATOR_TAGS_HDLC] = "Hdlc";
         list[DLMS_TRANSLATOR_TAGS_PDU_DLMS] = "Pdu";

--- a/development/include/TranslatorStandardTags.h
+++ b/development/include/TranslatorStandardTags.h
@@ -45,7 +45,7 @@
 class CTranslatorStandardTags {
 public:
     /// Get general tags.
-    static void GetGeneralTags(DLMS_TRANSLATOR_OUTPUT_TYPE type, std::map<unsigned long, std::string> &list) {
+    static void GetGeneralTags(DLMS_TRANSLATOR_OUTPUT_TYPE /*type*/, std::map<unsigned long, std::string> &list) {
         list[DLMS_COMMAND_SNRM] = "Snrm";
         list[DLMS_COMMAND_UNACCEPTABLE_FRAME] = "UnacceptableFrame";
         list[DLMS_COMMAND_DISCONNECT_MODE] = "DisconnectMode";
@@ -95,7 +95,7 @@ public:
     }
 
     // Get SN tags.
-    static void GetSnTags(DLMS_TRANSLATOR_OUTPUT_TYPE type, std::map<unsigned long, std::string> &list) {
+    static void GetSnTags(DLMS_TRANSLATOR_OUTPUT_TYPE /*type*/, std::map<unsigned long, std::string> &list) {
         list[DLMS_COMMAND_READ_REQUEST] = "readRequest";
         list[DLMS_COMMAND_WRITE_REQUEST] = "writeRequest";
         list[DLMS_COMMAND_WRITE_RESPONSE] = "writeResponse";
@@ -114,7 +114,7 @@ public:
     }
 
     // Get LN tags.
-    static void GetLnTags(DLMS_TRANSLATOR_OUTPUT_TYPE type, std::map<unsigned long, std::string> &list) {
+    static void GetLnTags(DLMS_TRANSLATOR_OUTPUT_TYPE /*type*/, std::map<unsigned long, std::string> &list) {
         list[DLMS_COMMAND_GET_REQUEST] = "get-request";
         list[DLMS_COMMAND_GET_REQUEST << 8 | DLMS_GET_COMMAND_TYPE_NORMAL] = "get-request-normal";
         list[DLMS_COMMAND_GET_REQUEST << 8 | DLMS_GET_COMMAND_TYPE_NEXT_DATA_BLOCK] = "get-request-next";
@@ -175,7 +175,7 @@ public:
     }
 
     // Get glo tags.
-    static void GetGloTags(DLMS_TRANSLATOR_OUTPUT_TYPE type, std::map<unsigned long, std::string> &list) {
+    static void GetGloTags(DLMS_TRANSLATOR_OUTPUT_TYPE /*type*/, std::map<unsigned long, std::string> &list) {
         list[DLMS_COMMAND_GLO_INITIATE_REQUEST] = "glo-initiate-request";
         list[DLMS_COMMAND_GLO_INITIATE_RESPONSE] = "glo-initiate-response";
         list[DLMS_COMMAND_GLO_GET_REQUEST] = "glo-get-request";
@@ -192,7 +192,7 @@ public:
     }
 
     // Get ded tags.
-    static void GetDedTags(DLMS_TRANSLATOR_OUTPUT_TYPE type, std::map<unsigned long, std::string> &list) {
+    static void GetDedTags(DLMS_TRANSLATOR_OUTPUT_TYPE /*type*/, std::map<unsigned long, std::string> &list) {
         list[DLMS_COMMAND_DED_INITIATE_REQUEST] = "ded-initiate-request";
         list[DLMS_COMMAND_DED_INITIATE_RESPONSE] = "ded-initiate-response";
         list[DLMS_COMMAND_DED_GET_REQUEST] = "ded-get-request";
@@ -205,7 +205,7 @@ public:
     }
 
     /// Get translator tags.
-    static void GetTranslatorTags(DLMS_TRANSLATOR_OUTPUT_TYPE type, std::map<unsigned long, std::string> &list) {
+    static void GetTranslatorTags(DLMS_TRANSLATOR_OUTPUT_TYPE /*type*/, std::map<unsigned long, std::string> &list) {
         list[DLMS_TRANSLATOR_TAGS_WRAPPER] = "Wrapper";
         list[DLMS_TRANSLATOR_TAGS_HDLC] = "Hdlc";
         list[DLMS_TRANSLATOR_TAGS_PDU_DLMS] = "xDLMS-APDU";

--- a/development/src/GXAPDU.cpp
+++ b/development/src/GXAPDU.cpp
@@ -191,7 +191,7 @@ int SetConformanceToArray(unsigned int value, CGXByteBuffer &data) {
  * @param cipher
  * @param data
  */
-int GetInitiateRequest(CGXDLMSSettings &settings, CGXCipher *cipher, CGXByteBuffer &data) {
+int GetInitiateRequest(CGXDLMSSettings &settings, CGXCipher *, CGXByteBuffer &data) {
     // Tag for xDLMS-Initiate request
     data.SetUInt8(DLMS_COMMAND_INITIATE_REQUEST);
     // Usage field for dedicated-key component.
@@ -304,7 +304,7 @@ void GetConformance(unsigned long value, CGXDLMSTranslatorStructure *xml) {
 }
 #endif  //DLMS_IGNORE_XML_TRANSLATOR
 int CGXAPDU::Parse(
-    bool initiateRequest, CGXDLMSSettings &settings, CGXCipher *cipher, CGXByteBuffer &data,
+    bool initiateRequest, CGXDLMSSettings &settings, CGXCipher *, CGXByteBuffer &data,
 #ifndef DLMS_IGNORE_XML_TRANSLATOR
     CGXDLMSTranslatorStructure *xml,
 #endif  //DLMS_IGNORE_XML_TRANSLATOR
@@ -333,9 +333,9 @@ int CGXAPDU::Parse(
 #ifndef DLMS_IGNORE_XML_TRANSLATOR
             if (xml != NULL) {
                 //NegotiatedQualityOfService
-                std::string str;
-                xml->IntegerToHex((int32_t)tag, 2, str);
-                xml->AppendLine(TRANSLATOR_GENERAL_TAGS_NEGOTIATED_QUALITY_OF_SERVICE, "", str);
+                std::string negotiatedQualityOfService;
+                xml->IntegerToHex((int32_t)tag, 2, negotiatedQualityOfService);
+                xml->AppendLine(TRANSLATOR_GENERAL_TAGS_NEGOTIATED_QUALITY_OF_SERVICE, "", negotiatedQualityOfService);
             }
 #endif  //DLMS_IGNORE_XML_TRANSLATOR
         }
@@ -344,7 +344,7 @@ int CGXAPDU::Parse(
         if (xml != NULL) {
             xml->AppendStartTag(DLMS_COMMAND_INITIATE_REQUEST);
         }
-#endif  //DLMS_IGNORE_XML_TRANSLATOR \
+#endif  //DLMS_IGNORE_XML_TRANSLATOR
     //Optional usage field of dedicated key.
         if ((ret = data.GetUInt8(&tag)) != 0) {
             return ret;
@@ -363,8 +363,8 @@ int CGXAPDU::Parse(
             }
 #ifndef DLMS_IGNORE_XML_TRANSLATOR
             if (xml != NULL) {
-                str = tmp.ToHexString(false);
-                xml->AppendLine(TRANSLATOR_GENERAL_TAGS_DEDICATED_KEY, "", str);
+                std::string dedicatedKey = tmp.ToHexString(false);
+                xml->AppendLine(TRANSLATOR_GENERAL_TAGS_DEDICATED_KEY, "", dedicatedKey);
             }
 #endif  //DLMS_IGNORE_XML_TRANSLATOR
         }
@@ -380,15 +380,16 @@ int CGXAPDU::Parse(
             settings.SetQualityOfService(tag);
 #ifndef DLMS_IGNORE_XML_TRANSLATOR
             if (xml != NULL && (initiateRequest || xml->GetOutputType() == DLMS_TRANSLATOR_OUTPUT_TYPE_SIMPLE_XML)) {
-                xml->IntegerToHex((int32_t)tag, 2, str);
-                xml->AppendLine(TRANSLATOR_GENERAL_TAGS_PROPOSED_QUALITY_OF_SERVICE, "", str);
+                std::string proposedQualityOfService;
+                xml->IntegerToHex((int32_t)tag, 2, proposedQualityOfService);
+                xml->AppendLine(TRANSLATOR_GENERAL_TAGS_PROPOSED_QUALITY_OF_SERVICE, "", proposedQualityOfService);
             }
 #endif  //DLMS_IGNORE_XML_TRANSLATOR
         } else {
 #ifndef DLMS_IGNORE_XML_TRANSLATOR
             if (xml != NULL && xml->GetOutputType() == DLMS_TRANSLATOR_OUTPUT_TYPE_STANDARD_XML) {
-                str = "true";
-                xml->AppendLine(TRANSLATOR_GENERAL_TAGS_RESPONSE_ALLOWED, "", str);
+                std::string responseAllowed = "true";
+                xml->AppendLine(TRANSLATOR_GENERAL_TAGS_RESPONSE_ALLOWED, "", responseAllowed);
             }
 #endif  //DLMS_IGNORE_XML_TRANSLATOR
         }
@@ -404,8 +405,9 @@ int CGXAPDU::Parse(
             settings.SetQualityOfService(len);
 #ifndef DLMS_IGNORE_XML_TRANSLATOR
             if (xml != NULL && xml->GetOutputType() == DLMS_TRANSLATOR_OUTPUT_TYPE_SIMPLE_XML) {
-                xml->IntegerToHex((int32_t)len, 2, str);
-                xml->AppendLine(TRANSLATOR_GENERAL_TAGS_PROPOSED_QUALITY_OF_SERVICE, "", str);
+                std::string proposedQualityOfService;
+                xml->IntegerToHex((int32_t)len, 2, proposedQualityOfService);
+                xml->AppendLine(TRANSLATOR_GENERAL_TAGS_PROPOSED_QUALITY_OF_SERVICE, "", proposedQualityOfService);
             }
 #endif  //DLMS_IGNORE_XML_TRANSLATOR
         }
@@ -422,19 +424,20 @@ int CGXAPDU::Parse(
                     return ret;
                 }
                 DLMS_SERVICE_ERROR type = (DLMS_SERVICE_ERROR)ch;
-                std::string str = CTranslatorStandardTags::ServiceErrorToString(type);
+                std::string serviceError = CTranslatorStandardTags::ServiceErrorToString(type);
                 if ((ret = data.GetUInt8(&ch)) != 0) {
                     return ret;
                 }
                 std::string value = CTranslatorStandardTags::GetServiceErrorValue(type, ch);
-                xml->AppendLine("x:" + str, "", value);
+                xml->AppendLine("x:" + serviceError, "", value);
                 xml->AppendEndTag(DLMS_TRANSLATOR_TAGS_INITIATE_ERROR);
             } else {
                 if ((ret = data.GetUInt8(&ch)) != 0) {
                     return ret;
                 }
-                xml->IntegerToHex((int32_t)ch, 2, str);
-                xml->AppendLine(DLMS_TRANSLATOR_TAGS_SERVICE, "", str);
+                std::string service;
+                xml->IntegerToHex((int32_t)ch, 2, service);
+                xml->AppendLine(DLMS_TRANSLATOR_TAGS_SERVICE, "", service);
                 if ((ret = data.GetUInt8(&ch)) != 0) {
                     return ret;
                 }
@@ -444,8 +447,8 @@ int CGXAPDU::Parse(
                     return ret;
                 }
                 std::string str1 = CTranslatorSimpleTags::ServiceErrorToString(type);
-                str = CTranslatorSimpleTags::GetServiceErrorValue(type, ch);
-                xml->AppendLine(str1, "", str);
+                std::string serviceErrorValue = CTranslatorSimpleTags::GetServiceErrorValue(type, ch);
+                xml->AppendLine(str1, "", serviceErrorValue);
                 xml->AppendEndTag(DLMS_TRANSLATOR_TAGS_SERVICE_ERROR);
             }
             xml->AppendEndTag(DLMS_COMMAND_CONFIRMED_SERVICE_ERROR);
@@ -567,7 +570,7 @@ int CGXAPDU::Parse(
             xml->IntegerToHex((int32_t)pduSize, 4, str);
             xml->AppendLine(TRANSLATOR_GENERAL_TAGS_PROPOSED_MAX_PDU_SIZE, "", str);
         }
-#endif  //DLMS_IGNORE_XML_TRANSLATOR \
+#endif  //DLMS_IGNORE_XML_TRANSLATOR
     //If client asks too high PDU.
         if (pduSize > settings.GetMaxServerPDUSize()) {
             settings.SetMaxReceivePDUSize(settings.GetMaxServerPDUSize());
@@ -1252,9 +1255,9 @@ int CGXAPDU::ParsePDU2(
                             str = CGXDLMSConverter::ToString(result);
                             xml->AppendComment(str);
                         }
-                        std::string str;
-                        xml->IntegerToHex((uint32_t)result, 2, str);
-                        xml->AppendLine(TRANSLATOR_GENERAL_TAGS_ASSOCIATION_RESULT, "", str);
+                        std::string resultStr;
+                        xml->IntegerToHex((uint32_t)result, 2, resultStr);
+                        xml->AppendLine(TRANSLATOR_GENERAL_TAGS_ASSOCIATION_RESULT, "", resultStr);
                         xml->AppendStartTag(TRANSLATOR_GENERAL_TAGS_RESULT_SOURCE_DIAGNOSTIC);
                     }
 #endif  //DLMS_IGNORE_XML_TRANSLATOR
@@ -1277,8 +1280,8 @@ int CGXAPDU::ParsePDU2(
                     calledAEQualifier.Set(&buff, buff.GetPosition(), len);
 #ifndef DLMS_IGNORE_XML_TRANSLATOR
                     if (xml != NULL) {
-                        str = calledAEQualifier.ToHexString(false);
-                        xml->AppendLine(DLMS_TRANSLATOR_TAGS_CALLED_AE_QUALIFIER, "", str);
+                        std::string qualifier = calledAEQualifier.ToHexString(false);
+                        xml->AppendLine(DLMS_TRANSLATOR_TAGS_CALLED_AE_QUALIFIER, "", qualifier);
                     }
 #endif  //DLMS_IGNORE_XML_TRANSLATOR
                 } else {
@@ -1302,12 +1305,12 @@ int CGXAPDU::ParsePDU2(
 #ifndef DLMS_IGNORE_XML_TRANSLATOR
                     if (xml != NULL) {
                         if (diagnostic != DLMS_SOURCE_DIAGNOSTIC_NONE) {
-                            str = CGXDLMSConverter::ToString(diagnostic);
-                            xml->AppendComment(str);
+                            std::string diagnosticStr = CGXDLMSConverter::ToString(diagnostic);
+                            xml->AppendComment(diagnosticStr);
                         }
-                        std::string str;
-                        xml->IntegerToHex((int32_t)diagnostic, 2, str);
-                        xml->AppendLine(TRANSLATOR_GENERAL_TAGS_ACSE_SERVICE_USER, "", str);
+                        std::string acseUser;
+                        xml->IntegerToHex((int32_t)diagnostic, 2, acseUser);
+                        xml->AppendLine(TRANSLATOR_GENERAL_TAGS_ACSE_SERVICE_USER, "", acseUser);
                         xml->AppendEndTag(TRANSLATOR_GENERAL_TAGS_RESULT_SOURCE_DIAGNOSTIC);
                     }
 #endif  //DLMS_IGNORE_XML_TRANSLATOR
@@ -1344,9 +1347,9 @@ int CGXAPDU::ParsePDU2(
 #ifndef DLMS_IGNORE_XML_TRANSLATOR
                     if (xml != NULL) {
                         //RespondingAPTitle
-                        std::string str;
-                        xml->IntegerToHex((int32_t)len, 2, str);
-                        xml->AppendLine(DLMS_TRANSLATOR_TAGS_CALLED_AP_INVOCATION_ID, "", str);
+                        std::string invocationId;
+                        xml->IntegerToHex((int32_t)len, 2, invocationId);
+                        xml->AppendLine(DLMS_TRANSLATOR_TAGS_CALLED_AP_INVOCATION_ID, "", invocationId);
                     }
 #endif  //DLMS_IGNORE_XML_TRANSLATOR
                 } else {
@@ -1371,8 +1374,8 @@ int CGXAPDU::ParsePDU2(
 #ifndef DLMS_IGNORE_XML_TRANSLATOR
                     if (xml != NULL) {
                         //RespondingAPTitle
-                        str = tmp.ToHexString(false);
-                        xml->AppendLine(TRANSLATOR_GENERAL_TAGS_RESPONDING_AP_TITLE, "", str);
+                        std::string title = tmp.ToHexString(false);
+                        xml->AppendLine(TRANSLATOR_GENERAL_TAGS_RESPONDING_AP_TITLE, "", title);
                     }
 #endif  //DLMS_IGNORE_XML_TRANSLATOR
                 }
@@ -1394,8 +1397,8 @@ int CGXAPDU::ParsePDU2(
 #ifndef DLMS_IGNORE_XML_TRANSLATOR
                 if (xml != NULL) {
                     //CallingAPTitle
-                    str = tmp.ToHexString(false);
-                    xml->AppendLine(TRANSLATOR_GENERAL_TAGS_CALLING_AP_TITLE, "", str);
+                    std::string title = tmp.ToHexString(false);
+                    xml->AppendLine(TRANSLATOR_GENERAL_TAGS_CALLING_AP_TITLE, "", title);
                 }
 #endif  //DLMS_IGNORE_XML_TRANSLATOR
                 break;
@@ -1434,9 +1437,9 @@ int CGXAPDU::ParsePDU2(
                 settings.SetUserID(tag);
 #ifndef DLMS_IGNORE_XML_TRANSLATOR
                 if (xml != NULL) {
-                    std::string str;
-                    xml->IntegerToHex((int32_t)tag, 2, str);
-                    xml->AppendLine(TRANSLATOR_GENERAL_TAGS_CALLING_AE_INVOCATION_ID, "", str);
+                    std::string invocationId;
+                    xml->IntegerToHex((int32_t)tag, 2, invocationId);
+                    xml->AppendLine(TRANSLATOR_GENERAL_TAGS_CALLING_AE_INVOCATION_ID, "", invocationId);
                 }
 #endif  //DLMS_IGNORE_XML_TRANSLATOR
                 break;
@@ -1452,10 +1455,10 @@ int CGXAPDU::ParsePDU2(
                     return ret;
                 }
                 if (tag == BER_TYPE_OCTET_STRING) {
-                    CGXByteBuffer tmp;
-                    tmp.Set(&buff, buff.GetPosition(), len2);
+                    CGXByteBuffer tmp2;
+                    tmp2.Set(&buff, buff.GetPosition(), len2);
                     CGXx509Certificate cert;
-                    if ((ret = CGXx509Certificate::FromByteArray(tmp, cert)) != 0) {
+                    if ((ret = CGXx509Certificate::FromByteArray(tmp2, cert)) != 0) {
                         return ret;
                     }
                     settings.SetServerPublicKeyCertificate(cert);
@@ -1472,9 +1475,9 @@ int CGXAPDU::ParsePDU2(
                     settings.SetUserID(tag);
 #ifndef DLMS_IGNORE_XML_TRANSLATOR
                     if (xml != NULL) {
-                        std::string str;
-                        xml->IntegerToHex((int32_t)tag, 2, str);
-                        xml->AppendLine(TRANSLATOR_GENERAL_TAGS_CALLED_AE_INVOCATION_ID, "", str);
+                        std::string invocationId;
+                        xml->IntegerToHex((int32_t)tag, 2, invocationId);
+                        xml->AppendLine(TRANSLATOR_GENERAL_TAGS_CALLED_AE_INVOCATION_ID, "", invocationId);
                     }
 #endif  //DLMS_IGNORE_XML_TRANSLATOR
                 }
@@ -1492,10 +1495,10 @@ int CGXAPDU::ParsePDU2(
                 }
                 if (tag == BER_TYPE_OCTET_STRING) {
                     //If public key certificate is coming part of AARQ.
-                    CGXByteBuffer tmp;
-                    tmp.Set(&buff, buff.GetPosition(), len2);
+                    CGXByteBuffer tmp2;
+                    tmp2.Set(&buff, buff.GetPosition(), len2);
                     CGXx509Certificate cert;
-                    if ((ret = CGXx509Certificate::FromByteArray(tmp, cert)) != 0) {
+                    if ((ret = CGXx509Certificate::FromByteArray(tmp2, cert)) != 0) {
                         return ret;
                     }
                     settings.SetClientPublicKeyCertificate(cert);
@@ -1518,8 +1521,9 @@ int CGXAPDU::ParsePDU2(
                     settings.SetUserID(tag);
 #ifndef DLMS_IGNORE_XML_TRANSLATOR
                     if (xml != NULL) {
-                        xml->IntegerToHex((int32_t)tag, 2, str);
-                        xml->AppendLine(TRANSLATOR_GENERAL_TAGS_RESPONDING_AE_INVOCATION_ID, "", str);
+                        std::string invocationId;
+                        xml->IntegerToHex((int32_t)tag, 2, invocationId);
+                        xml->AppendLine(TRANSLATOR_GENERAL_TAGS_RESPONDING_AE_INVOCATION_ID, "", invocationId);
                     }
 #endif  //DLMS_IGNORE_XML_TRANSLATOR
                 }
@@ -1550,9 +1554,9 @@ int CGXAPDU::ParsePDU2(
 #ifndef DLMS_IGNORE_XML_TRANSLATOR
                 if (xml != NULL) {
                     //CallingApInvocationId
-                    std::string str;
-                    xml->IntegerToHex((int32_t)len, 2, str);
-                    xml->AppendLine(DLMS_TRANSLATOR_TAGS_CALLING_AP_INVOCATION_ID, "Value", str);
+                    std::string invocationId;
+                    xml->IntegerToHex((int32_t)len, 2, invocationId);
+                    xml->AppendLine(DLMS_TRANSLATOR_TAGS_CALLING_AP_INVOCATION_ID, "Value", invocationId);
                 }
 #endif  //DLMS_IGNORE_XML_TRANSLATOR
                 break;
@@ -1715,7 +1719,7 @@ int CGXAPDU::ParsePDU(
         }
     }
 #endif  //DLMS_IGNORE_XML_TRANSLATOR
-    ret = ParsePDU2(
+    int retVal = ParsePDU2(
         settings, cipher, buff, result, diagnostic
 #ifndef DLMS_IGNORE_XML_TRANSLATOR
         ,
@@ -1732,7 +1736,7 @@ int CGXAPDU::ParsePDU(
         }
     }
 #endif  //DLMS_IGNORE_XML_TRANSLATOR
-    return ret;
+    return retVal;
 }
 
 /**

--- a/development/src/GXAsn1Converter.cpp
+++ b/development/src/GXAsn1Converter.cpp
@@ -305,81 +305,81 @@ int CGXAsn1Converter::GetBytes(CGXByteBuffer &bb, CGXAsn1Base *target, int &coun
         count += bb.GetSize() - start;
         bb.Set(&tmp);
         return 0;
-    } else if (CGXAsn1Variant *a = dynamic_cast<CGXAsn1Variant *>(target)) {
-        switch (a->GetValue().vt) {
+    } else if (CGXAsn1Variant *var = dynamic_cast<CGXAsn1Variant *>(target)) {
+        switch (var->GetValue().vt) {
             case DLMS_DATA_TYPE_STRING:
                 bb.SetUInt8(BER_TYPE_PRINTABLE_STRING);
-                GXHelpers::SetObjectCount((unsigned long)a->GetValue().strVal.length(), bb);
-                bb.AddString(a->GetValue().strVal);
+                GXHelpers::SetObjectCount((unsigned long)var->GetValue().strVal.length(), bb);
+                bb.AddString(var->GetValue().strVal);
                 break;
             case DLMS_DATA_TYPE_INT8:
                 if ((ret = bb.SetInt8(BER_TYPE_INTEGER)) == 0 && (ret = GXHelpers::SetObjectCount(1, bb)) == 0 &&
-                    (ret = bb.SetInt8(a->GetValue().bVal)) == 0) {
+                    (ret = bb.SetInt8(var->GetValue().bVal)) == 0) {
                 }
                 break;
             case DLMS_DATA_TYPE_INT16:
                 if ((ret = bb.SetUInt8(BER_TYPE_INTEGER)) == 0 && (ret = GXHelpers::SetObjectCount(2, bb)) == 0 &&
-                    (ret = bb.SetInt16(a->GetValue().iVal)) == 0) {
+                    (ret = bb.SetInt16(var->GetValue().iVal)) == 0) {
                 }
                 break;
             case DLMS_DATA_TYPE_INT32:
                 if ((ret = bb.SetUInt8(BER_TYPE_INTEGER)) == 0 && (ret = GXHelpers::SetObjectCount(4, bb)) == 0 &&
-                    (ret = bb.SetInt32(a->GetValue().lVal)) == 0) {
+                    (ret = bb.SetInt32(var->GetValue().lVal)) == 0) {
                 }
                 break;
             case DLMS_DATA_TYPE_INT64:
                 if ((ret = bb.SetUInt8(BER_TYPE_INTEGER)) == 0 && (ret = GXHelpers::SetObjectCount(8, bb)) == 0 &&
-                    (ret = bb.SetInt64(a->GetValue().llVal)) == 0) {
+                    (ret = bb.SetInt64(var->GetValue().llVal)) == 0) {
                 }
                 break;
             case DLMS_DATA_TYPE_OCTET_STRING:
                 if ((ret = bb.SetUInt8(BER_TYPE_OCTET_STRING)) == 0 &&
-                    (ret = GXHelpers::SetObjectCount(a->GetValue().size, bb)) == 0 &&
-                    (ret = bb.Set(a->GetValue().byteArr, a->GetValue().size)) == 0) {
+                    (ret = GXHelpers::SetObjectCount(var->GetValue().size, bb)) == 0 &&
+                    (ret = bb.Set(var->GetValue().byteArr, var->GetValue().size)) == 0) {
                 }
                 break;
             case DLMS_DATA_TYPE_BOOLEAN:
                 if ((ret = bb.SetUInt8(BER_TYPE_BOOLEAN)) == 0 && (ret = bb.SetUInt8(1)) == 0 &&
-                    (ret = bb.SetUInt8(a->GetValue().bVal ? 255 : 0)) == 0) {
+                    (ret = bb.SetUInt8(var->GetValue().bVal ? 255 : 0)) == 0) {
                 }
                 break;
             default:
                 ret = DLMS_ERROR_CODE_INVALID_PARAMETER;
         }
-    } else if (CGXAsn1Integer *a = dynamic_cast<CGXAsn1Integer *>(target)) {
+    } else if (CGXAsn1Integer *i = dynamic_cast<CGXAsn1Integer *>(target)) {
         bb.SetUInt8(BER_TYPE_INTEGER);
-        GXHelpers::SetObjectCount(a->GetValue().GetSize(), bb);
-        bb.Set(a->GetValue().GetData(), a->GetValue().GetSize());
+        GXHelpers::SetObjectCount(i->GetValue().GetSize(), bb);
+        bb.Set(i->GetValue().GetData(), i->GetValue().GetSize());
     } else if (target == NULL) {
         bb.SetUInt8(BER_TYPE_NULL);
         GXHelpers::SetObjectCount(0, bb);
-    } else if (CGXAsn1ObjectIdentifier *a = dynamic_cast<CGXAsn1ObjectIdentifier *>(target)) {
+    } else if (CGXAsn1ObjectIdentifier *oi = dynamic_cast<CGXAsn1ObjectIdentifier *>(target)) {
         bb.SetUInt8(BER_TYPE_OBJECT_IDENTIFIER);
         CGXByteBuffer t;
         t.Capacity(10);
-        if ((ret = a->GetEncoded(t)) == 0) {
+        if ((ret = oi->GetEncoded(t)) == 0) {
             GXHelpers::SetObjectCount(t.GetSize(), bb);
             bb.Set(&t);
         }
-    } else if (CGXAsn1Set *a = dynamic_cast<CGXAsn1Set *>(target)) {
+    } else if (CGXAsn1Set *s = dynamic_cast<CGXAsn1Set *>(target)) {
         CGXByteBuffer tmp2;
-        if (a->GetValue() != NULL) {
+        if (s->GetValue() != NULL) {
             cnt = 0;
-            int count;
-            if ((ret = GetBytes(tmp2, a->GetKey(), count)) != 0) {
+            int val;
+            if ((ret = GetBytes(tmp2, s->GetKey(), val)) != 0) {
                 return ret;
             }
-            cnt += count;
-            count = 0;
-            if ((ret = GetBytes(tmp2, a->GetValue(), count)) != 0) {
+            cnt += val;
+            val = 0;
+            if ((ret = GetBytes(tmp2, s->GetValue(), val)) != 0) {
                 return ret;
             }
-            cnt += count;
+            cnt += val;
             tmp.SetUInt8(BER_TYPE_CONSTRUCTED | BER_TYPE_SEQUENCE);
             GXHelpers::SetObjectCount(cnt, tmp);
             tmp.Set(&tmp2);
         } else {
-            GetBytes(tmp2, a->GetKey(), count);
+            GetBytes(tmp2, s->GetKey(), count);
             tmp = tmp2;
         }
         // Update len.
@@ -389,13 +389,13 @@ int CGXAsn1Converter::GetBytes(CGXByteBuffer &bb, CGXAsn1Base *target, int &coun
         bb.Set(&tmp);
         count = bb.GetSize() - cnt;
         return ret;
-    } else if (CGXAsn1Utf8String *a = dynamic_cast<CGXAsn1Utf8String *>(target)) {
-        str = a->GetValue();
+    } else if (CGXAsn1Utf8String *u = dynamic_cast<CGXAsn1Utf8String *>(target)) {
+        str = u->GetValue();
         if ((ret = bb.SetUInt8(BER_TYPE_UTF8_STRING)) == 0 &&
             (ret = GXHelpers::SetObjectCount((unsigned long)str.length(), bb)) == 0 && (ret = bb.AddString(str)) == 0) {
         }
-    } else if (CGXAsn1Ia5String *a = dynamic_cast<CGXAsn1Ia5String *>(target)) {
-        str = a->GetValue();
+    } else if (CGXAsn1Ia5String *ia5 = dynamic_cast<CGXAsn1Ia5String *>(target)) {
+        str = ia5->GetValue();
         if ((ret = bb.SetUInt8(BER_TYPE_IA5_STRING)) == 0 &&
             (ret = GXHelpers::SetObjectCount((unsigned long)str.length(), bb)) == 0 && (ret = bb.AddString(str)) == 0) {
         }
@@ -455,8 +455,8 @@ DLMS_PKCS_TYPE CGXAsn1Converter::GetCertificateType(CGXByteBuffer &data, CGXAsn1
         if (CGXx509Certificate::FromByteArray(data, cert) == 0) {
             ret = DLMS_PKCS_TYPE_X509_CERTIFICATE;
         } else {
-            CGXPkcs10 cert;
-            if (CGXPkcs10::FromByteArray(data, cert) == 0) {
+            CGXPkcs10 pkcs10;
+            if (CGXPkcs10::FromByteArray(data, pkcs10) == 0) {
                 ret = DLMS_PKCS_TYPE_PKCS10;
             }
         }


### PR DESCRIPTION
This commit fixes a number of compiler warnings, including:
- Unused parameters
- Shadowing variables
- Multi-line comments
- Anonymous structs