### PR TITLE
Fix Windows UINT64 formatting in GXDLMSVariant

### DIFF
--- a/development/src/GXDLMSVariant.cpp
+++ b/development/src/GXDLMSVariant.cpp
@@ -162,7 +162,7 @@ int CGXDLMSVariant::Convert(CGXDLMSVariant *item, DLMS_DATA_TYPE type) {
 #if _MSC_VER > 1000
             sprintf_s(buff, 250, "%llu", tmp.ullVal);
 #else
-            sprintf(buff, "%I64u", tmp.llVal);
+            sprintf(buff, "%I64u", tmp.ullVal);
 #endif
 #else
             sprintf(buff, "%llu", tmp.ullVal);


### PR DESCRIPTION
## Summary
- ensure the Windows-specific %I64u formatting in CGXDLMSVariant uses the unsigned 64-bit value
- regenerate build artifacts via the standard Release configuration

## Testing
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
- cmake --build build --parallel $(nproc)
- (cd build && ctest --output-on-failure)
- (cd build && cmake --build . --target doc)


------
https://chatgpt.com/codex/tasks/task_e_68fee51d2b74832d8783fdb0e7ac2cae