### PR TITLE
Fix Windows uint64 conversion format

### DIFF
--- a/development/src/GXDLMSVariant.cpp
+++ b/development/src/GXDLMSVariant.cpp
@@ -162,7 +162,7 @@ int CGXDLMSVariant::Convert(CGXDLMSVariant *item, DLMS_DATA_TYPE type) {
 #if _MSC_VER > 1000
             sprintf_s(buff, 250, "%llu", tmp.ullVal);
 #else
-            sprintf(buff, "%I64u", tmp.ullVal);
+            sprintf(buff, "%llu", tmp.ullVal);
 #endif
 #else
             sprintf(buff, "%llu", tmp.ullVal);


### PR DESCRIPTION
## Summary
- use the standard %llu format when printing uint64 values on older MSVC builds to avoid warnings

## Testing
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
- cmake --build build --config Release
- ctest --output-on-failure
- cmake --build build --target doc > ../doc.log 2>&1

------
https://chatgpt.com/codex/tasks/task_e_68fef3d388c4832db12be00c6ed49062