### PR TITLE
Clean up unused buffers and tighten shadowing cases

### DIFF
--- a/development/src/GXBigInteger.cpp
+++ b/development/src/GXBigInteger.cpp
@@ -183,8 +183,8 @@ int CGXBigInteger::FromByteBuffer(CGXByteBuffer &value) {
     unsigned short ival;
     Clear();
     Capacity((uint16_t)(value.GetSize() / 4));
-    for (uint32_t pos = value.GetSize() - 4; pos > -1; pos = pos - 4) {
-        ret = value.GetUInt32(pos, &tmp);
+    for (int pos = static_cast<int>(value.GetSize()) - 4; pos >= 0; pos -= 4) {
+        ret = value.GetUInt32(static_cast<uint32_t>(pos), &tmp);
         if (ret != 0) {
             break;
         }

--- a/development/src/GXCipher.cpp
+++ b/development/src/GXCipher.cpp
@@ -447,7 +447,6 @@ int CGXCipher::Encrypt(
     unsigned char J0[16] = {0};
     unsigned char S[16] = {0};
     CGXByteBuffer nonse;
-    CGXByteBuffer aad;
     if (systemTitle.GetSize() != 8) {
         return DLMS_ERROR_CODE_INVALID_PARAMETER;
     }

--- a/development/src/GXDLMSCharge.cpp
+++ b/development/src/GXDLMSCharge.cpp
@@ -358,6 +358,7 @@ int CGXDLMSCharge::SetValue(CGXDLMSSettings &settings, CGXDLMSValueEventArg &e) 
                 m_ChargeConfiguration = (DLMS_CHARGE_CONFIGURATION)e.GetValue().ToInteger();
                 break;
             }
+            /* fall through */
         case 10:
             if (e.GetValue().vt == DLMS_DATA_TYPE_OCTET_STRING) {
                 e.GetValue().GetBytes(bb);

--- a/development/src/GXDLMSClient.cpp
+++ b/development/src/GXDLMSClient.cpp
@@ -335,8 +335,7 @@ int CGXDLMSClient::ParseSNObjectItem(CGXDLMSVariant &value, bool ignoreInactiveO
     if (pObj != NULL) {
         pObj->SetShortName(sn);
         pObj->SetVersion(version);
-        int cnt = ln.GetSize();
-        assert(cnt == 6);
+        assert(ln.GetSize() == 6);
         CGXDLMSObject::SetLogicalName(pObj, ln);
         std::string ln2;
         pObj->GetLogicalName(ln2);
@@ -417,7 +416,6 @@ int CGXDLMSClient::ParseLNObjectItem(CGXDLMSVariant &value, bool ignoreInactiveO
                 return DLMS_ERROR_CODE_INVALID_PARAMETER;
             }
             pObj->SetVersion(version);
-            int cnt;
             // attribute_access_descriptor Start
             if (value.Arr[3].Arr[0].vt != DLMS_DATA_TYPE_ARRAY) {
                 delete pObj;
@@ -472,8 +470,7 @@ int CGXDLMSClient::ParseLNObjectItem(CGXDLMSVariant &value, bool ignoreInactiveO
                 }
             }
             // method_access_item End
-            cnt = ln.GetSize();
-            assert(cnt == 6);
+            assert(ln.GetSize() == 6);
             m_Settings.GetObjects().push_back(pObj);
         }
     }

--- a/development/src/GXDLMSConverter.cpp
+++ b/development/src/GXDLMSConverter.cpp
@@ -1598,8 +1598,8 @@ void CGXDLMSConverter::UpdateObisCodes() {
         sb << OBIS_CODES_GAS_5;
         sb << OBIS_CODES_GAS_6;
 #endif  //DLMS_IGNORE_OBIS_GAS
-        std::string str = sb.str();
-        std::vector<std::string> rows = GXHelpers::Split(str, "\r\n", true);
+        std::string concatenated = sb.str();
+        std::vector<std::string> rows = GXHelpers::Split(concatenated, "\r\n", true);
         int row = 0;
         std::string last;
         for (std::vector<std::string>::iterator it = rows.begin(); it != rows.end(); ++it) {
@@ -1612,8 +1612,8 @@ void CGXDLMSConverter::UpdateObisCodes() {
             if (obis.size() != 6) {
                 obis = GXHelpers::Split(items[0], ".\r\n", false);
             }
-            std::string str = items[3] + "; " + items[4] + "; " + items[5] + "; " + items[6] + "; " + items[7];
-            m_Codes.push_back(new CGXStandardObisCode(obis, str, items[1], items[2]));
+            std::string description = items[3] + "; " + items[4] + "; " + items[5] + "; " + items[6] + "; " + items[7];
+            m_Codes.push_back(new CGXStandardObisCode(obis, description, items[1], items[2]));
             ++row;
             last = *it;
         }
@@ -1635,13 +1635,13 @@ void CGXDLMSConverter::GetDescription(
 
 void CGXDLMSConverter::UpdateOBISCodeInformation(CGXDLMSObjectCollection &objects) {
     UpdateObisCodes();
-    for (std::vector<CGXDLMSObject *>::iterator it = objects.begin(); it != objects.end(); ++it) {
+    for (std::vector<CGXDLMSObject *>::iterator objectIt = objects.begin(); objectIt != objects.end(); ++objectIt) {
         std::string ln;
-        (*it)->GetLogicalName(ln);
+        (*objectIt)->GetLogicalName(ln);
         std::vector<CGXStandardObisCode *> list;
-        m_Codes.Find(ln, (*it)->GetObjectType(), list);
+        m_Codes.Find(ln, (*objectIt)->GetObjectType(), list);
         CGXStandardObisCode *code = list.at(0);
-        (*it)->SetDescription(code->GetDescription());
+        (*objectIt)->SetDescription(code->GetDescription());
         //If std::string is used
         if (code->GetDataType().find("10") != std::string::npos) {
             code->SetUIDataType("10");
@@ -1689,7 +1689,7 @@ void CGXDLMSConverter::UpdateOBISCodeInformation(CGXDLMSObjectCollection &object
             }
         }
         //Unix time
-        else if ((*it)->GetObjectType() == DLMS_OBJECT_TYPE_DATA &&
+        else if ((*objectIt)->GetObjectType() == DLMS_OBJECT_TYPE_DATA &&
                  CGXStandardObisCodeCollection::EqualsMask2("0.0.1.1.0.255", ln)) {
             code->SetUIDataType("25");
         }
@@ -1702,12 +1702,12 @@ void CGXDLMSConverter::UpdateOBISCodeInformation(CGXDLMSObjectCollection &object
             sscanf(code->GetDataType().c_str(), "%d", &value);
 #endif
             DLMS_DATA_TYPE type = (DLMS_DATA_TYPE)value;
-            switch ((*it)->GetObjectType()) {
+            switch ((*objectIt)->GetObjectType()) {
                 case DLMS_OBJECT_TYPE_DATA:
                 case DLMS_OBJECT_TYPE_REGISTER:
                 case DLMS_OBJECT_TYPE_REGISTER_ACTIVATION:
                 case DLMS_OBJECT_TYPE_EXTENDED_REGISTER:
-                    (*it)->SetDataType(2, type);
+                    (*objectIt)->SetDataType(2, type);
                     break;
                 default:
                     break;
@@ -1721,19 +1721,19 @@ void CGXDLMSConverter::UpdateOBISCodeInformation(CGXDLMSObjectCollection &object
             sscanf(code->GetUIDataType().c_str(), "%d", &value);
 #endif
             DLMS_DATA_TYPE type = (DLMS_DATA_TYPE)value;
-            switch ((*it)->GetObjectType()) {
+            switch ((*objectIt)->GetObjectType()) {
                 case DLMS_OBJECT_TYPE_DATA:
                 case DLMS_OBJECT_TYPE_REGISTER:
                 case DLMS_OBJECT_TYPE_REGISTER_ACTIVATION:
                 case DLMS_OBJECT_TYPE_EXTENDED_REGISTER:
-                    (*it)->SetUIDataType(2, type);
+                    (*objectIt)->SetUIDataType(2, type);
                     break;
                 default:
                     break;
             }
         }
-        for (std::vector<CGXStandardObisCode *>::iterator it = list.begin(); it != list.end(); ++it) {
-            delete *it;
+        for (std::vector<CGXStandardObisCode *>::iterator codeIt = list.begin(); codeIt != list.end(); ++codeIt) {
+            delete *codeIt;
         }
         list.clear();
     }


### PR DESCRIPTION
## Summary
- remove the unused CGXByteBuffer `aad` in `GXCipher::Encrypt`
- fix reverse iteration in `CGXBigInteger::FromByteBuffer` to avoid unsigned comparisons
- clarify fall-through, assertions, and iterator naming to silence shadowing warnings in the DLMS client/charge/converter helpers

## Testing
- manual `c++` compile of `development/src/GXCipher.cpp` with `-Werror` (other warnings demoted) to ensure no unused-variable diagnostics remain
- attempted `cmake --build build --parallel $(nproc)` with global `-Werror`; aborted because the wider codebase emits numerous pre-existing warnings treated as errors


------
https://chatgpt.com/codex/tasks/task_e_68ff57f8e998832d874b792035b2abfb