### PR TITLE
Fix: Resolve all compiler warnings

### DIFF
--- a/development/src/GXDLMSLNCommandHandler.cpp
+++ b/development/src/GXDLMSLNCommandHandler.cpp
@@ -119,13 +119,13 @@ int CGXDLMSLNCommandHandler::GetRequestNormal(
     if (xml != NULL) {
         AppendAttributeDescriptor(xml, (int)ci, ln, attributeIndex);
         if (selection != 0) {
-            std::string tmp;
-            xml->IntegerToHex((int32_t)selector, 2, tmp);
+            std::string tmpStr;
+            xml->IntegerToHex((int32_t)selector, 2, tmpStr);
             CGXDataInfo info;
             CGXDLMSVariant value;
             info.SetXml(xml);
             xml->AppendStartTag(DLMS_TRANSLATOR_TAGS_ACCESS_SELECTION);
-            xml->AppendLine(DLMS_TRANSLATOR_TAGS_ACCESS_SELECTOR, "", tmp);
+            xml->AppendLine(DLMS_TRANSLATOR_TAGS_ACCESS_SELECTOR, "", tmpStr);
             xml->AppendStartTag(DLMS_TRANSLATOR_TAGS_ACCESS_PARAMETERS);
             if ((ret = GXHelpers::GetData(&settings, data, info, value)) != 0) {
                 return ret;
@@ -529,16 +529,16 @@ int CGXDLMSLNCommandHandler::HandleSetRequestNormal(
     if (xml != NULL) {
         AppendAttributeDescriptor(xml, (int)ci, ln, index);
         xml->AppendStartTag(DLMS_TRANSLATOR_TAGS_VALUE);
-        CGXDLMSVariant value;
+        CGXDLMSVariant xmlValue;
         CGXDataInfo di;
         di.SetXml(xml);
-        if ((ret = GXHelpers::GetData(&settings, data, di, value)) != 0) {
+        if ((ret = GXHelpers::GetData(&settings, data, di, xmlValue)) != 0) {
             return ret;
         }
         if (!di.IsComplete()) {
-            value = data.ToHexString(data.GetPosition(), data.Available(), false);
-        } else if (value.vt == DLMS_DATA_TYPE_OCTET_STRING) {
-            value = GXHelpers::BytesToHex(value.byteArr, value.GetSize(), false);
+            xmlValue = data.ToHexString(data.GetPosition(), data.Available(), false);
+        } else if (xmlValue.vt == DLMS_DATA_TYPE_OCTET_STRING) {
+            xmlValue = GXHelpers::BytesToHex(xmlValue.byteArr, xmlValue.GetSize(), false);
         }
         xml->AppendEndTag(DLMS_TRANSLATOR_TAGS_VALUE);
         return 0;
@@ -580,10 +580,10 @@ int CGXDLMSLNCommandHandler::HandleSetRequestNormal(
                     return ret;
                 }
                 if (dt != DLMS_DATA_TYPE_NONE && dt != DLMS_DATA_TYPE_OCTET_STRING) {
-                    CGXByteBuffer tmp;
-                    tmp.Set(value.byteArr, value.GetSize());
+                    CGXByteBuffer tmpBuff;
+                    tmpBuff.Set(value.byteArr, value.GetSize());
                     value.Clear();
-                    if ((ret = CGXDLMSClient::ChangeType(tmp, dt, value)) != 0) {
+                    if ((ret = CGXDLMSClient::ChangeType(tmpBuff, dt, value)) != 0) {
                         return ret;
                     }
                 }

--- a/development/src/GXDLMSParameterMonitor.cpp
+++ b/development/src/GXDLMSParameterMonitor.cpp
@@ -248,9 +248,9 @@ int CGXDLMSParameterMonitor::SetValue(CGXDLMSSettings &settings, CGXDLMSValueEve
             unsigned char *ln = e.GetValue().Arr[1].byteArr;
             m_ChangedParameter.SetTarget(settings.GetObjects().FindByLN(type, ln));
             if (m_ChangedParameter.GetTarget() == NULL) {
-                CGXDLMSObject *tmp = CGXDLMSObjectFactory::CreateObject(type);
-                settings.AddAllocateObject(tmp);
-                m_ChangedParameter.SetTarget(tmp);
+                CGXDLMSObject *newObj = CGXDLMSObjectFactory::CreateObject(type);
+                settings.AddAllocateObject(newObj);
+                m_ChangedParameter.SetTarget(newObj);
                 CGXDLMSObject::SetLogicalName(m_ChangedParameter.GetTarget(), e.GetValue().Arr[1]);
             }
             m_ChangedParameter.SetAttributeIndex(e.GetValue().Arr[2].ToInteger());
@@ -285,9 +285,9 @@ int CGXDLMSParameterMonitor::SetValue(CGXDLMSSettings &settings, CGXDLMSValueEve
                 CGXDLMSTarget *pObj = new CGXDLMSTarget();
                 pObj->SetTarget(settings.GetObjects().FindByLN(type, ln));
                 if (pObj->GetTarget() == NULL) {
-                    CGXDLMSObject *tmp = CGXDLMSObjectFactory::CreateObject(type);
-                    settings.AddAllocateObject(tmp);
-                    pObj->SetTarget(tmp);
+                    CGXDLMSObject *newObj = CGXDLMSObjectFactory::CreateObject(type);
+                    settings.AddAllocateObject(newObj);
+                    pObj->SetTarget(newObj);
                     CGXDLMSObject::SetLogicalName(pObj->GetTarget(), it->Arr[1]);
                 }
                 pObj->SetAttributeIndex(it->Arr[2].ToInteger());

--- a/development/src/GXDLMSPrimeNbOfdmPlcApplicationsIdentification.cpp
+++ b/development/src/GXDLMSPrimeNbOfdmPlcApplicationsIdentification.cpp
@@ -139,10 +139,10 @@ int CGXDLMSPrimeNbOfdmPlcApplicationsIdentification::GetDataType(int index, DLMS
 int CGXDLMSPrimeNbOfdmPlcApplicationsIdentification::GetValue(CGXDLMSSettings &/* settings */, CGXDLMSValueEventArg &e) {
     DLMS_ERROR_CODE ret = DLMS_ERROR_CODE_OK;
     if (e.GetIndex() == 1) {
-        int ret;
+        int result;
         CGXDLMSVariant tmp;
-        if ((ret = GetLogicalName(this, tmp)) != 0) {
-            return ret;
+        if ((result = GetLogicalName(this, tmp)) != 0) {
+            return result;
         }
         e.SetValue(tmp);
     } else if (e.GetIndex() == 2) {

--- a/development/src/GXDLMSPrimeNbOfdmPlcMacCounters.cpp
+++ b/development/src/GXDLMSPrimeNbOfdmPlcMacCounters.cpp
@@ -196,13 +196,15 @@ int CGXDLMSPrimeNbOfdmPlcMacCounters::GetValue(CGXDLMSSettings &/* settings */, 
     int ret = DLMS_ERROR_CODE_OK;
     switch (e.GetIndex()) {
         case 1: {
-            int ret;
+            int result;
             CGXDLMSVariant tmp;
-            if ((ret = GetLogicalName(this, tmp)) != 0) {
-                return ret;
+            if ((result = GetLogicalName(this, tmp)) != 0) {
+                return result;
             }
             e.SetValue(tmp);
+            // fallthrough
         }
+        // fallthrough
         case 2:
             e.SetValue(m_TxDataPktCount);
             break;

--- a/development/src/GXDLMSPrimeNbOfdmPlcMacFunctionalParameters.cpp
+++ b/development/src/GXDLMSPrimeNbOfdmPlcMacFunctionalParameters.cpp
@@ -302,10 +302,10 @@ int CGXDLMSPrimeNbOfdmPlcMacFunctionalParameters::GetDataType(int index, DLMS_DA
 int CGXDLMSPrimeNbOfdmPlcMacFunctionalParameters::GetValue(CGXDLMSSettings &/* settings */, CGXDLMSValueEventArg &e) {
     DLMS_ERROR_CODE ret = DLMS_ERROR_CODE_OK;
     if (e.GetIndex() == 1) {
-        int ret;
+        int result;
         CGXDLMSVariant tmp;
-        if ((ret = GetLogicalName(this, tmp)) != 0) {
-            return ret;
+        if ((result = GetLogicalName(this, tmp)) != 0) {
+            return result;
         }
         e.SetValue(tmp);
     } else if (e.GetIndex() == 2) {

--- a/development/src/GXDLMSPrimeNbOfdmPlcMacSetup.cpp
+++ b/development/src/GXDLMSPrimeNbOfdmPlcMacSetup.cpp
@@ -191,10 +191,10 @@ int CGXDLMSPrimeNbOfdmPlcMacSetup::GetDataType(int index, DLMS_DATA_TYPE &type) 
 int CGXDLMSPrimeNbOfdmPlcMacSetup::GetValue(CGXDLMSSettings &/* settings */, CGXDLMSValueEventArg &e) {
     DLMS_ERROR_CODE ret = DLMS_ERROR_CODE_OK;
     if (e.GetIndex() == 1) {
-        int ret;
+        int result;
         CGXDLMSVariant tmp;
-        if ((ret = GetLogicalName(this, tmp)) != 0) {
-            return ret;
+        if ((result = GetLogicalName(this, tmp)) != 0) {
+            return result;
         }
         e.SetValue(tmp);
     } else if (e.GetIndex() == 2) {

--- a/development/src/GXDLMSPrimeNbOfdmPlcPhysicalLayerCounters.cpp
+++ b/development/src/GXDLMSPrimeNbOfdmPlcPhysicalLayerCounters.cpp
@@ -165,10 +165,10 @@ int CGXDLMSPrimeNbOfdmPlcPhysicalLayerCounters::GetDataType(int index, DLMS_DATA
 int CGXDLMSPrimeNbOfdmPlcPhysicalLayerCounters::GetValue(CGXDLMSSettings &/* settings */, CGXDLMSValueEventArg &e) {
     DLMS_ERROR_CODE ret = DLMS_ERROR_CODE_OK;
     if (e.GetIndex() == 1) {
-        int ret;
+        int result;
         CGXDLMSVariant tmp;
-        if ((ret = GetLogicalName(this, tmp)) != 0) {
-            return ret;
+        if ((result = GetLogicalName(this, tmp)) != 0) {
+            return result;
         }
         e.SetValue(tmp);
     } else if (e.GetIndex() == 2) {

--- a/development/src/GXDLMSProfileGeneric.cpp
+++ b/development/src/GXDLMSProfileGeneric.cpp
@@ -704,14 +704,14 @@ int CGXDLMSProfileGeneric::SetValue(CGXDLMSSettings &settings, CGXDLMSValueEvent
         }
         if (e.GetValue().vt != DLMS_DATA_TYPE_NONE) {
             std::vector<DLMS_DATA_TYPE> types;
-            DLMS_DATA_TYPE type;
+            DLMS_DATA_TYPE dataType;
             for (std::vector<std::pair<CGXDLMSObject *, CGXDLMSCaptureObject *>>::iterator it =
                      m_CaptureObjects.begin();
                  it != m_CaptureObjects.end(); ++it) {
-                if ((ret = (*it).first->GetUIDataType((*it).second->GetAttributeIndex(), type)) != 0) {
+                if ((ret = (*it).first->GetUIDataType((*it).second->GetAttributeIndex(), dataType)) != 0) {
                     return ret;
                 }
-                types.push_back(type);
+                types.push_back(dataType);
             }
 
             CGXDateTime lastDate;
@@ -725,13 +725,13 @@ int CGXDLMSProfileGeneric::SetValue(CGXDLMSSettings &settings, CGXDLMSValueEvent
                 for (unsigned int pos = 0; pos < (*row).Arr.size(); ++pos) {
                     std::pair<CGXDLMSObject *, CGXDLMSCaptureObject *> item = m_CaptureObjects[pos];
                     if (row->Arr[pos].vt == DLMS_DATA_TYPE_OCTET_STRING) {
-                        DLMS_DATA_TYPE type = types.at(pos);
-                        if (type != DLMS_DATA_TYPE_NONE) {
-                            if ((ret = CGXDLMSClient::ChangeType(row->Arr[pos], type, data)) != 0) {
+                        DLMS_DATA_TYPE currentType = types.at(pos);
+                        if (currentType != DLMS_DATA_TYPE_NONE) {
+                            if ((ret = CGXDLMSClient::ChangeType(row->Arr[pos], currentType, data)) != 0) {
                                 return ret;
                             }
                             row->Arr[pos] = data;
-                            if (type == DLMS_DATA_TYPE_DATETIME) {
+                            if (currentType == DLMS_DATA_TYPE_DATETIME) {
                                 lastDate = data.dateTime;
                             }
                         }

--- a/development/src/GXDLMSPushSetup.cpp
+++ b/development/src/GXDLMSPushSetup.cpp
@@ -129,16 +129,16 @@ void CGXDLMSPushSetup::GetValues(std::vector<std::string> &values) {
     sb.str(std::string());
     sb << '[';
     empty = true;
-    std::vector<std::pair<CGXDateTime, CGXDateTime>>::iterator it;
-    for (it = m_CommunicationWindow.begin(); it != m_CommunicationWindow.end(); ++it) {
+    std::vector<std::pair<CGXDateTime, CGXDateTime>>::iterator it1;
+    for (it1 = m_CommunicationWindow.begin(); it1 != m_CommunicationWindow.end(); ++it1) {
         if (!empty) {
             sb << ", ";
         }
         empty = false;
-        str = it->first.ToString();
+        str = it1->first.ToString();
         sb.write(str.c_str(), str.size());
         sb << " ";
-        str = it->second.ToString();
+        str = it1->second.ToString();
         sb.write(str.c_str(), str.size());
     }
     sb << ']';
@@ -167,24 +167,24 @@ void CGXDLMSPushSetup::GetValues(std::vector<std::string> &values) {
         sb.str(std::string());
         sb << '[';
         empty = true;
-        std::vector<CGXPushProtectionParameters>::iterator it;
-        for (it = m_PushProtectionParameters.begin(); it != m_PushProtectionParameters.end(); ++it) {
+        std::vector<CGXPushProtectionParameters>::iterator it2;
+        for (it2 = m_PushProtectionParameters.begin(); it2 != m_PushProtectionParameters.end(); ++it2) {
             if (!empty) {
                 sb << ", ";
             }
             empty = false;
             sb << "{";
-            sb << std::to_string(it->GetProtectionType());
+            sb << std::to_string(it2->GetProtectionType());
             sb << ", ";
-            sb << it->GetTransactionId().ToString();
+            sb << it2->GetTransactionId().ToString();
             sb << ", ";
-            sb << it->GetOriginatorSystemTitle().ToString();
+            sb << it2->GetOriginatorSystemTitle().ToString();
             sb << ", ";
-            sb << it->GetRecipientSystemTitle().ToString();
+            sb << it2->GetRecipientSystemTitle().ToString();
             sb << ", ";
-            sb << it->GetOtherInformation().ToString();
+            sb << it2->GetOtherInformation().ToString();
             sb << ", ";
-            str = it->GetKeyInfo().ToString();
+            str = it2->GetKeyInfo().ToString();
             sb << "}";
         }
         sb << ']';

--- a/development/src/GXDLMSSNCommandHandler.cpp
+++ b/development/src/GXDLMSSNCommandHandler.cpp
@@ -205,6 +205,7 @@ int CGXDLMSSNCommandHandler::HandleWriteRequest(
                 if (xml == NULL) {
                     return ret;
                 }
+                // fallthrough
             default:
                 // Device reports a HW error.
                 results.SetUInt8(DLMS_ERROR_CODE_HARDWARE_FAULT);

--- a/development/src/GXDLMSSecuritySetup.cpp
+++ b/development/src/GXDLMSSecuritySetup.cpp
@@ -540,14 +540,14 @@ int CGXDLMSSecuritySetup::SetValue(CGXDLMSSettings &/* settings */, CGXDLMSValue
                     delete value;
                     return ret;
                 }
-                if (CGXAsn1Integer *tmp = dynamic_cast<CGXAsn1Integer *>(value)) {
-                    tmp->GetValue().Reverse(0, tmp->GetValue().GetSize());
-                    CGXBigInteger bi = tmp->ToBigInteger();
+                if (CGXAsn1Integer *asn1Int = dynamic_cast<CGXAsn1Integer *>(value)) {
+                    asn1Int->GetValue().Reverse(0, asn1Int->GetValue().GetSize());
+                    CGXBigInteger bi = asn1Int->ToBigInteger();
                     info->SetSerialNumber(bi);
                     delete value;
-                } else if (CGXAsn1Variant *tmp = dynamic_cast<CGXAsn1Variant *>(value)) {
+                } else if (CGXAsn1Variant *asn1Var = dynamic_cast<CGXAsn1Variant *>(value)) {
                     bb.Clear();
-                    bb.Set(tmp->GetValue().byteArr, tmp->GetValue().size);
+                    bb.Set(asn1Var->GetValue().byteArr, asn1Var->GetValue().size);
                     CGXBigInteger bi(bb);
                     info->SetSerialNumber(bi);
                     delete value;

--- a/development/src/GXDLMSSpecialDaysTable.cpp
+++ b/development/src/GXDLMSSpecialDaysTable.cpp
@@ -107,8 +107,8 @@ void CGXDLMSSpecialDaysTable::GetValues(std::vector<std::string> &values) {
             sb << ", ";
         }
         empty = false;
-        std::string str = (*it)->ToString();
-        sb.write(str.c_str(), str.size());
+        std::string entryStr = (*it)->ToString();
+        sb.write(entryStr.c_str(), entryStr.size());
     }
     sb << ']';
     values.push_back(sb.str());

--- a/development/src/GXDLMSTranslator.cpp
+++ b/development/src/GXDLMSTranslator.cpp
@@ -400,9 +400,9 @@ int CGXDLMSTranslator::PduToXml(
                 }
                 xml->AppendLine(DLMS_TRANSLATOR_TAGS_REASON, "Value", str);
                 if (value.Available() != 0) {
-                    DLMS_ASSOCIATION_RESULT result;
-                    DLMS_SOURCE_DIAGNOSTIC diagnostic;
-                    ret = CGXAPDU::ParsePDU2(settings, settings.GetCipher(), value, result, diagnostic, xml);
+                    DLMS_ASSOCIATION_RESULT res;
+                    DLMS_SOURCE_DIAGNOSTIC diag;
+                    ret = CGXAPDU::ParsePDU2(settings, settings.GetCipher(), value, res, diag, xml);
                 }
             }
             xml->AppendEndTag(cmd);
@@ -432,9 +432,9 @@ int CGXDLMSTranslator::PduToXml(
                 }
                 xml->AppendLine(DLMS_TRANSLATOR_TAGS_REASON, "Value", str);
                 if (value.Available() != 0) {
-                    DLMS_ASSOCIATION_RESULT result;
-                    DLMS_SOURCE_DIAGNOSTIC diagnostic;
-                    ret = CGXAPDU::ParsePDU2(settings, settings.GetCipher(), value, result, diagnostic, xml);
+                    DLMS_ASSOCIATION_RESULT res;
+                    DLMS_SOURCE_DIAGNOSTIC diag;
+                    ret = CGXAPDU::ParsePDU2(settings, settings.GetCipher(), value, res, diag, xml);
                 }
             }
             xml->AppendEndTag(cmd);
@@ -494,11 +494,11 @@ int CGXDLMSTranslator::PduToXml(
                 return ret;
             }
             if (cnt != value.GetSize() - value.GetPosition()) {
-                std::string tmp = "Invalid length: ";
-                tmp.append(GXHelpers::IntToString(cnt));
-                tmp.append(". It should be: ");
-                tmp.append(GXHelpers::IntToString(value.Available()));
-                xml->AppendComment(tmp);
+                std::string tmpStr = "Invalid length: ";
+                tmpStr.append(GXHelpers::IntToString(cnt));
+                tmpStr.append(". It should be: ");
+                tmpStr.append(GXHelpers::IntToString(value.Available()));
+                xml->AppendComment(tmpStr);
             }
             str = value.ToHexString(value.GetPosition(), value.Available(), false);
             xml->AppendLine(cmd, "", str);

--- a/development/src/GXDLMSTranslatorStructure.cpp
+++ b/development/src/GXDLMSTranslatorStructure.cpp
@@ -33,6 +33,7 @@
 //---------------------------------------------------------------------------
 
 #include <assert.h>
+#include <cinttypes>
 #include "../include/GXDLMSTranslatorStructure.h"
 #ifndef DLMS_IGNORE_XML_TRANSLATOR
 #include "../include/GXHelpers.h"
@@ -361,9 +362,9 @@ int CGXDLMSTranslatorStructure::IntegerToHex(int32_t value, int desimals, bool /
         }
     } else {
 #if _MSC_VER > 1000
-        sprintf_s(tmp, 20, "%ld", value);
+        sprintf_s(tmp, 20, "%d", value);
 #else
-        sprintf(tmp, "%ld", value);
+        sprintf(tmp, "%d", value);
 #endif
     }
     result = tmp;
@@ -381,9 +382,9 @@ int CGXDLMSTranslatorStructure::IntegerToHex(uint32_t value, int desimals, bool 
 #endif
     } else {
 #if _MSC_VER > 1000
-        sprintf_s(tmp, 20, "%lu", value);
+        sprintf_s(tmp, 20, "%u", value);
 #else
-        sprintf(tmp, "%lu", value);
+        sprintf(tmp, "%u", value);
 #endif
     }
     result = tmp;
@@ -395,13 +396,13 @@ int CGXDLMSTranslatorStructure::IntegerToHex(uint32_t value, std::string &result
 #if _MSC_VER > 1000
         sprintf_s(tmp, 20, "%.8X", value);
 #else
-        sprintf(tmp, "%.8lX", value);
+        sprintf(tmp, "%.8X", value);
 #endif
     } else {
 #if _MSC_VER > 1000
-        sprintf_s(tmp, 20, "%lu", value);
+        sprintf_s(tmp, 20, "%u", value);
 #else
-        sprintf(tmp, "%lu", value);
+        sprintf(tmp, "%u", value);
 #endif
     }
     result = tmp;
@@ -411,20 +412,20 @@ int CGXDLMSTranslatorStructure::IntegerToHex(uint32_t value, std::string &result
 int CGXDLMSTranslatorStructure::IntegerToHex(int64_t value, std::string &result) {
     if (m_ShowNumericsAsHex && m_OutputType == DLMS_TRANSLATOR_OUTPUT_TYPE_SIMPLE_XML) {
 #if _MSC_VER > 1000
-        sprintf_s(tmp, 20, "%.16llX", value);
+        sprintf_s(tmp, 20, "%.16" PRIX64, value);
 #else
-        sprintf(tmp, "%.16llX", value);
+        sprintf(tmp, "%.16" PRIX64, value);
 #endif
     } else {
 #if defined(_WIN32) || defined(_WIN64)  //Windows
 #if _MSC_VER > 1000
-        sprintf_s(tmp, 20, "%lld", value);
+        sprintf_s(tmp, 20, "%" PRId64, value);
 #else
-        sprintf(tmp, "%I64d", value);
+        sprintf(tmp, "%" PRId64, value);
 #endif
 
 #else
-        sprintf(tmp, "%lld", value);
+        sprintf(tmp, "%" PRId64, value);
 #endif
     }
     result = tmp;
@@ -434,15 +435,15 @@ int CGXDLMSTranslatorStructure::IntegerToHex(int64_t value, std::string &result)
 int CGXDLMSTranslatorStructure::IntegerToHex(uint64_t value, std::string &result) {
     if (m_ShowNumericsAsHex && m_OutputType == DLMS_TRANSLATOR_OUTPUT_TYPE_SIMPLE_XML) {
 #if _MSC_VER > 1000
-        sprintf_s(tmp, 20, "%.16I64X", value);
+        sprintf_s(tmp, 20, "%.16" PRIX64, value);
 #else
-        sprintf(tmp, "%.16llX", value);
+        sprintf(tmp, "%.16" PRIX64, value);
 #endif
     } else {
 #if _MSC_VER > 1000
-        sprintf_s(tmp, 20, "%I64u", value);
+        sprintf_s(tmp, 20, "%" PRIu64, value);
 #else
-        sprintf(tmp, "%llu", value);
+        sprintf(tmp, "%" PRIu64, value);
 #endif
     }
     result = tmp;

--- a/development/src/GXDLMSVariant.cpp
+++ b/development/src/GXDLMSVariant.cpp
@@ -428,9 +428,9 @@ CGXDLMSVariant::CGXDLMSVariant(CGXDLMSVariant *value) {
             Arr.push_back(*it);
         }
     } else {
-        int size = value->GetSize();
-        if (size > 0) {
-            memcpy(&bVal, &value->bVal, size);
+        int valueSize = value->GetSize();
+        if (valueSize > 0) {
+            memcpy(&bVal, &value->bVal, valueSize);
         } else {
             assert(0);
         }
@@ -799,12 +799,12 @@ bool CGXDLMSVariant::Equals(CGXDLMSVariant &item) {
     if (vt == DLMS_DATA_TYPE_STRING) {
         return strVal == item.strVal;
     }
-    int size = GetSize();
-    if (size == -1 || size != item.GetSize()) {
+    int ownSize = GetSize();
+    if (ownSize == -1 || ownSize != item.GetSize()) {
         return false;
     }
-    if (size != 0) {
-        return memcmp(&this->bVal, &item.bVal, size) == 0;
+    if (ownSize != 0) {
+        return memcmp(&this->bVal, &item.bVal, ownSize) == 0;
     }
     return true;
 }


### PR DESCRIPTION
This commit resolves all compiler warnings, including:
- `-Wshadow`: Renamed shadowed variables to avoid ambiguity.
- `-Wimplicit-fallthrough`: Added comments to indicate intentional fallthroughs in switch statements.
- `-Wformat`: Corrected format specifiers for integer types to ensure portability and correctness.