### PR TITLE
docs: Add class documentation and fix Doxygen warnings

### DIFF
--- a/development/include/GXAPDU.h
+++ b/development/include/GXAPDU.h
@@ -51,6 +51,15 @@
 // a client. Also unsolicited (received without a request) messages are
 // available.
 /////////////////////////////////////////////////////////////////////////////
+/**
+ * The services to access the attributes and methods of COSEM objects are
+ * determined on DLMS/COSEM Application layer. The services are carried by
+ * Application Protocol Data Units (APDUs).
+ *
+ * In DLMS/COSEM the meter is primarily a server, and the controlling system is
+ * a client. Also unsolicited (received without a request) messages are
+ * available.
+ */
 class CGXAPDU {
     friend class CGXDLMSTranslator;
 
@@ -114,6 +123,8 @@ public:
     * @param settings
     *            DLMS settings.
     * @param cipher
+    * @param encryptedData
+    *            Encrypted data.
     * @param data
     *            Generated user information.
     */

--- a/development/include/GXAsn1Converter.h
+++ b/development/include/GXAsn1Converter.h
@@ -53,6 +53,9 @@
 #include "GXAsn1Helpers.h"
 #include "GXAsn1Time.h"
 
+/**
+* ASN.1 Converter.
+*/
 class CGXAsn1Converter {
 private:
     friend class CGXPkcs8;
@@ -103,6 +106,7 @@ public:
     /**
      Convert ASN1 objects to byte array.
      @param objects ASN.1 objects->
+     @param value ASN.1 objects as byte array.
      Returns  ASN.1 objects as byte array.
      */
     static int ToByteArray(CGXAsn1Base *objects, CGXByteBuffer &value);
@@ -119,6 +123,7 @@ public:
      Get system title from the subject.
 
      @param subject Subject.
+     @param value System title.
      Returns System title.
      */
     static int SystemTitleFromSubject(std::string &subject, CGXByteBuffer &value);
@@ -127,6 +132,7 @@ public:
      Get system title in hex string from the subject.
 
      @param subject Subject.
+     @param value System title.
      Returns System title.
      */
     static int HexSystemTitleFromSubject(std::string &subject, std::string &value);

--- a/development/include/GXAsn1Integer.h
+++ b/development/include/GXAsn1Integer.h
@@ -41,7 +41,7 @@
 #include "GXAsn1Base.h"
 
 /**
- ASN1 bit string.
+ * ASN.1 Integer.
 */
 class CGXAsn1Integer: public CGXAsn1Base {
 private:
@@ -70,7 +70,7 @@ public:
 
     /**
      Constructor
-     @param data Integer.
+     @param value Integer.
     */
     CGXAsn1Integer(CGXByteBuffer &value) {
         m_Value = value;

--- a/development/include/GXBigInteger.h
+++ b/development/include/GXBigInteger.h
@@ -38,6 +38,9 @@
 #include "GXBytebuffer.h"
 #include "GXByteArray.h"
 
+/**
+ * Big integer.
+*/
 class CGXBigInteger {
 private:
     friend class CGXPrivateKey;
@@ -106,7 +109,8 @@ public:
     /**
      Constructor value.
 
-     @param value Byte array Data in MSB format.
+     @param values Byte array Data in MSB format.
+     @param count Number of values.
     */
     CGXBigInteger(const unsigned char *values, uint16_t count);
 

--- a/development/include/GXByteArray.h
+++ b/development/include/GXByteArray.h
@@ -40,6 +40,9 @@
 #include "enums.h"
 #include "GXBytebuffer.h"
 
+/**
+ * Byte array.
+*/
 class CGXByteArray {
     friend class CGXCipher;
     friend class CGXByteBuffer;
@@ -138,8 +141,10 @@ public:
      * Compares, whether two given arrays are similar starting from current
      * position.
      *
-     * @param arr
+     * @param buff
      *            Array to compare.
+     * @param length
+     *            Length of the array to compare.
      * @return True, if arrays are similar. False, if the arrays differ.
      */
     bool Compare(unsigned char *buff, unsigned long length);
@@ -170,6 +175,8 @@ public:
     /**
         * Returns data as byte array.
         *
+        * @param index Starting index.
+        * @param count Number of bytes.
         * @param bb Byte buffer as a byte array.
         */
     int SubArray(unsigned long index, int count, CGXByteArray &bb);
@@ -177,6 +184,8 @@ public:
     /**
     * Returns data as byte array.
     *
+    * @param index Starting index.
+    * @param count Number of bytes.
     * @param bb Byte buffer as a byte array.
     */
     int SubArray(unsigned long index, int count, CGXByteBuffer &bb);

--- a/development/include/GXDLMS.h
+++ b/development/include/GXDLMS.h
@@ -46,6 +46,9 @@
 #include "GXDLMSLNParameters.h"
 #include "GXDLMSSNParameters.h"
 
+/**
+ * DLMS/COSEM library.
+*/
 class CGXDLMS {
 private:
     friend class CGXDLMSClient;
@@ -200,8 +203,12 @@ public:
      *
      * @param settings
      *            DLMS settings.
+     * @param command
+     *            DLMS command.
      * @param data
      *            Wrapped data.
+     * @param reply
+     *            Wrapper frames.
      * @return Wrapper frames.
     */
     static int
@@ -298,6 +305,8 @@ public:
      *
      * @param buff
      *            byte array.
+     * @param address
+     *            HDLC address.
      * @return HDLC address.
      */
     static int GetHDLCAddress(CGXByteBuffer &buff, unsigned long &address);
@@ -313,6 +322,10 @@ public:
      *            Received data.
      * @param index
      *            Position.
+     * @param source
+     *            Source address.
+     * @param target
+     *            Target address.
      * @return True, if client and server address match.
      */
     static int CheckHdlcAddress(

--- a/development/include/GXDLMSClient.h
+++ b/development/include/GXDLMSClient.h
@@ -41,6 +41,9 @@
 #include "GXDateTime.h"
 #include "GXDLMSAccessItem.h"
 
+/**
+ * DLMS client.
+*/
 class CGXDLMSClient {
 protected:
     friend class CGXDLMSSchedule;
@@ -513,6 +516,8 @@ public:
     *
     * @param list
     *            DLMS objects to read.
+    * @param reply
+    *            Generated messages.
     * @return Read request as byte array.
     */
     int ReadList(std::vector<std::pair<CGXDLMSObject *, unsigned char>> &list, std::vector<CGXByteBuffer> &reply);
@@ -522,6 +527,8 @@ public:
     *
     * @param list
     *            DLMS objects to read.
+    * @param reply
+    *            Generated messages.
     * @return Write request as byte array.
     */
     int WriteList(std::vector<std::pair<CGXDLMSObject *, unsigned char>> &list, std::vector<CGXByteBuffer> &reply);
@@ -535,7 +542,7 @@ public:
     *            Object type.
     * @param index
     *            Attribute index where data is write.
-    * @param value
+    * @param data
     *            Data to Write.
     * @param reply
     *             Generated write message(s).
@@ -555,7 +562,7 @@ public:
    *            Object type.
    * @param index
    *            Attribute index where data is write.
-   * @param value
+   * @param data
    *            Data to Write.
    * @param parameters
    *            Selective access parameters.
@@ -577,7 +584,7 @@ public:
   *            Object type.
   * @param index
   *            Attribute index where data is write.
-  * @param value
+  * @param data
   *            Data to Write.
   * @param parameters
   *            Selective access parameters.
@@ -598,7 +605,7 @@ public:
     *            Object type.
     * @param index
     *            Attribute index where data is write.
-    * @param value
+    * @param data
     *            Data to Write.
     * @param parameters
     *            Selective access parameters.
@@ -668,8 +675,8 @@ public:
     *            Method index.
     * @param data
     *            Method data.
-    * @param type
-    *            Data type.
+    * @param reply
+    *            Generated messages.
     * @return DLMS action message.
     */
     int Method(CGXDLMSObject *item, int index, CGXDLMSVariant &data, std::vector<CGXByteBuffer> &reply);
@@ -684,8 +691,10 @@ public:
     *            Method index.
     * @param data
     *            Method data.
-    * @param type
+    * @param dataType
     *            Data type.
+    * @param reply
+    *            Generated messages.
     * @return DLMS action message.
     */
     int Method(
@@ -701,10 +710,10 @@ public:
    *            Object type.
    * @param methodIndex
    *            Method index.
-   * @param value
+   * @param data
    *            Method data.
-   * @param dataType
-   *            Data type.
+   * @param reply
+   *            Generated messages.
    * @return DLMS action message.
    */
     int Method(
@@ -721,10 +730,12 @@ public:
     *            Object type.
     * @param methodIndex
     *            Method index.
-    * @param value
+    * @param data
     *            Method data.
     * @param dataType
     *            Data type.
+    * @param reply
+    *            Generated messages.
     * @return DLMS action message.
     */
     int Method(
@@ -741,8 +752,10 @@ public:
    *            Object type.
    * @param methodIndex
    *            Method index.
-   * @param value
+   * @param data
    *            Method data.
+   * @param reply
+   *            Generated messages.
    * @return DLMS action message.
    */
     int Method(
@@ -759,6 +772,8 @@ public:
     *            Zero bases start index.
     * @param count
     *            Rows count to read.
+    * @param reply
+    *            Generated messages.
     * @return Read message as byte array.
     */
     int ReadRowsByEntry(CGXDLMSProfileGeneric *pg, int index, int count, std::vector<CGXByteBuffer> &reply);
@@ -773,6 +788,10 @@ public:
     *            Zero bases start index.
     * @param count
     *            Rows count to read.
+    * @param columns
+    *            Columns to read.
+    * @param reply
+    *            Generated messages.
     * @return Read message as byte array.
     */
     int ReadRowsByEntry(
@@ -785,12 +804,14 @@ public:
     * Read rows by range. Use this method to read Profile Generic table between
     * dates.
     *
-    * @param pg
+    * @param pObject
     *            Profile generic object to read.
     * @param start
     *            Start time.
     * @param end
     *            End time.
+    * @param reply
+    *            Generated messages.
     * @return Generated read message.
     */
     int ReadRowsByRange(
@@ -807,6 +828,8 @@ public:
      *            Start time.
      * @param end
      *            End time.
+     * @param reply
+     *            Generated messages.
      * @return Generated read message.
      */
     int ReadRowsByRange(CGXDLMSProfileGeneric *pg, struct tm *start, struct tm *end, std::vector<CGXByteBuffer> &reply);
@@ -821,6 +844,10 @@ public:
     *            Start time.
     * @param end
     *            End time.
+    * @param columns
+    *            Columns to read.
+    * @param reply
+    *            Generated messages.
     * @return Generated read message.
     */
     int ReadRowsByRange(

--- a/development/include/GXDLMSImageTransfer.h
+++ b/development/include/GXDLMSImageTransfer.h
@@ -45,6 +45,8 @@
 /**
 Online help:
 http://www.gurux.fi/Gurux.DLMS.Objects.GXDLMSImageTransfer
+
+Provides the services for initiating, transferring, verifying and activating an Image.
 */
 class CGXDLMSImageTransfer: public CGXDLMSObject {
     unsigned long m_ImageBlockSize;
@@ -75,7 +77,7 @@ public:
 
     /**
      * Provides information about the transfer status of each
-     * ImageBlock. Each bit in the bit-std::string provides information about
+     * ImageBlock. Each bit in the bit-string provides information about
      * one individual ImageBlock.
     */
     std::string &GetImageTransferredBlocksStatus();

--- a/development/include/GXDLMSLNCommandHandler.h
+++ b/development/include/GXDLMSLNCommandHandler.h
@@ -40,6 +40,9 @@
 #include "GXDLMSSettings.h"
 #include "GXDLMSConnectionEventArgs.h"
 
+/**
+ * Handle LN commands.
+*/
 class CGXDLMSLNCommandHandler {
     /**
  * Handle get request normal command.
@@ -82,8 +85,15 @@ public:
     /**
     * Handle get request next data block command.
     *
+    * @param settings DLMS settings.
+    * @param invokeID Invoke ID.
+    * @param server Server.
     * @param data
     *            Received data.
+    * @param replyData Reply data.
+    * @param xml XML translator.
+    * @param streaming Is streaming active.
+    * @param cipheredCommand Ciphered command.
     */
     static int GetRequestNextDataBlock(
         CGXDLMSSettings &settings, unsigned char invokeID, CGXDLMSServer *server, CGXByteBuffer &data,
@@ -125,8 +135,13 @@ public:
     /**
   * Handle action request.
   *
-  * @param reply
-  *            Received data from the client.
+  * @param settings DLMS settings.
+  * @param server Server.
+  * @param data Received data from the client.
+  * @param replyData Reply data.
+  * @param connectionInfo Connection information.
+  * @param xml XML translator.
+  * @param cipheredCommand Ciphered command.
   * @return Reply.
   */
     static int HandleMethodRequest(

--- a/development/include/GXDLMSLNParameters.h
+++ b/development/include/GXDLMSLNParameters.h
@@ -115,6 +115,8 @@ public:
      *
      * @param settings
      *            DLMS settings.
+     * @param invokeId
+     *            Invoke ID.
      * @param command
      *            Command.
      * @param commandType
@@ -123,6 +125,10 @@ public:
      *            Attribute descriptor.
      * @param data
      *            Data.
+     * @param status
+     *            Status.
+     * @param cipheredCommand
+     *            Ciphered command.
      */
     CGXDLMSLNParameters(
         CGXDLMSSettings *settings, unsigned long invokeId, DLMS_COMMAND command, int commandType,

--- a/development/include/GXDLMSLongTransaction.h
+++ b/development/include/GXDLMSLongTransaction.h
@@ -41,6 +41,9 @@
 #include "GXDLMSValueEventArg.h"
 #include "GXDLMSValueEventCollection.h"
 
+/**
+ * Long transaction.
+*/
 class CGXDLMSLongTransaction {
 private:
     /**
@@ -76,7 +79,6 @@ public:
     /**
  * Constructor.
  *
- * @param targets
  * @param command
  * @param data
  */

--- a/development/include/GXDLMSNotify.h
+++ b/development/include/GXDLMSNotify.h
@@ -45,6 +45,9 @@
 #include "GXDLMSClient.h"
 #include "GXDLMSObjectFactory.h"
 
+/**
+ * DLMS notify service.
+*/
 class CGXDLMSNotify {
 private:
 protected:
@@ -193,6 +196,8 @@ public:
      *            Date time. Set to NULL or Date(0) if not used
      * @param data
      *            Notification body.
+     * @param reply
+     *            Generated messages.
      * @return Generated data notification message(s).
      */
     int GenerateDataNotificationMessages(struct tm *date, CGXByteBuffer &data, std::vector<CGXByteBuffer> &reply);
@@ -204,6 +209,8 @@ public:
      *            Date time. Set To Min or Max if not added.
      * @param objects
      *            List of objects and attribute indexes to notify.
+     * @param reply
+     *            Generated messages.
      * @return Generated data notification message(s).
      */
     int GenerateDataNotificationMessages(
@@ -219,6 +226,8 @@ public:
      *            Date time. Set to NULL or Date(0) if not used.
      * @param push
      *            Target Push object.
+     * @param reply
+     *            Generated messages.
      * @return Generated data notification message(s).
      */
     int GeneratePushSetupMessages(struct tm *date, CGXDLMSPushSetup *push, std::vector<CGXByteBuffer> &reply);
@@ -230,6 +239,8 @@ public:
     *
     * @param data
     *            Received value.
+    * @param items
+    *            Parsed objects.
     * @return Array of objects and called indexes.
     */
     int ParsePush(std::vector<CGXDLMSVariant> &data, std::vector<std::pair<CGXDLMSObject *, unsigned char>> &items);

--- a/development/include/GXDLMSProfileGeneric.h
+++ b/development/include/GXDLMSProfileGeneric.h
@@ -76,6 +76,16 @@ class CGXDLMSServer;
 /**
 Online help:
 http://www.gurux.fi/Gurux.DLMS.Objects.GXDLMSProfileGeneric
+
+ This class is used to model the periodical logging of monitoring results.
+ The Profile generic class is configurable by the various attributes and can
+ be used flexibly for various purposes, for example:
+<ul>
+ <li>traditional load profile,</li>
+ <li>recording billing period values of various energy types and demand,</li>
+ <li>recording events,</li>
+ <li>recording alarms.</li>
+</ul>
 */
 class CGXDLMSProfileGeneric: public CGXDLMSObject {
 private:
@@ -123,6 +133,8 @@ public:
     *            Is read by entry or range.
     * @param parameters
     *            Received parameters where columns information is found.
+    * @param columns
+    *            Selected columns.
     * @return Selected columns.
     */
     int GetSelectedColumns(

--- a/development/include/GXDLMSSNCommandHandler.h
+++ b/development/include/GXDLMSSNCommandHandler.h
@@ -41,6 +41,9 @@
 #include "GXDLMSValueEventCollection.h"
 #include "GXSNInfo.h"
 
+/**
+ * Handle SN commands.
+*/
 class CGXDLMSSNCommandHandler {
     /**
 * Find Short Name object.
@@ -105,8 +108,18 @@ public:
     /**
     * Handle write request.
     *
-    * @param reply
+    * @param settings
+    *            DLMS settings.
+    * @param server
+    *            DLMS server.
+    * @param data
     *            Received data from the client.
+    * @param replyData
+    *            Reply data.
+    * @param xml
+    *            XML translator.
+    * @param cipheredCommand
+    *            Ciphered command.
     * @return Reply.
     */
     static int HandleWriteRequest(

--- a/development/include/GXDLMSSNParameters.h
+++ b/development/include/GXDLMSSNParameters.h
@@ -89,6 +89,8 @@ public:
      *            DLMS settings.
      * @param command
      *            Command.
+     * @param count
+     *            Item count.
      * @param commandType
      *            command type.
      * @param attributeDescriptor

--- a/development/include/GXDLMSSapAssignment.h
+++ b/development/include/GXDLMSSapAssignment.h
@@ -42,6 +42,12 @@
 /**
 Online help:
 http://www.gurux.fi/Gurux.DLMS.Objects.GXDLMSSapAssignment
+
+ This IC allows assigning a logical name to a SAP. This offers the possibility of designing a
+ flexible addressing scheme. With this object, it is possible to build a list of (SAP, logical
+ name) pairs.
+
+NOTE! This is an obsolete class.
 */
 class CGXDLMSSapAssignment: public CGXDLMSObject {
     std::map<int, std::string> m_SapAssignmentList;
@@ -62,6 +68,7 @@ public:
 
     /**
      Constructor.
+     @param ln Logical Name of the object.
      @param sn Short Name of the object.
     */
     CGXDLMSSapAssignment(std::string ln, unsigned short sn);

--- a/development/include/GXDLMSSecureClient.h
+++ b/development/include/GXDLMSSecureClient.h
@@ -37,6 +37,9 @@
 
 #include "GXDLMSClient.h"
 
+/**
+ * DLMS client with ciphering.
+*/
 class CGXDLMSSecureClient: public CGXDLMSClient {
 private:
     CGXCipher m_Cipher;
@@ -70,6 +73,8 @@ public:
     *            Key Encrypting Key, also known as Master key.
     * @param data
     *            Data to encrypt.
+    * @param reply
+    *            Encrypted data.
     * @return Encrypt data.
     */
     static int Encrypt(CGXByteBuffer &kek, CGXByteBuffer &data, CGXByteBuffer &reply);
@@ -81,6 +86,8 @@ public:
     *            Key Encrypting Key, also known as Master key.
     * @param data
     *            Data to decrypt.
+    * @param reply
+    *            Decrypted data.
     * @return Decrypted data.
     */
     static int Decrypt(CGXByteBuffer &kek, CGXByteBuffer &data, CGXByteBuffer &reply);

--- a/development/include/GXDLMSServer.h
+++ b/development/include/GXDLMSServer.h
@@ -52,6 +52,9 @@
 class CGXDLMSProfileGeneric;
 class CGXServerReply;
 
+/**
+ * DLMS server.
+*/
 class CGXDLMSServer {
     friend class CGXDLMSProfileGeneric;
     friend class CGXDLMSValueEventArg;
@@ -524,7 +527,7 @@ public:
      * is defined by the device manufacturer. If the referencing is wrong, the
      * SNMR message will fail.
      *
-     * @see #getMaxReceivePDUSize
+     * @see #GetMaxReceivePDUSize
      * @return Is logical name referencing used.
      */
     bool GetUseLogicalNameReferencing();
@@ -550,6 +553,9 @@ public:
      *
      * @param data
      *            Received data from the client.
+     * @param reply
+     *            Response to the request. Response is NULL if request packet is
+     *         not complete.
      * @return Response to the request. Response is NULL if request packet is
      *         not complete.
      */
@@ -558,8 +564,13 @@ public:
     /**
     * Handles client request.
     *
+    * @param connectionInfo
+    *            Connection information.
     * @param data
     *            Received data from the client.
+    * @param reply
+    *            Response to the request. Response is NULL if request packet is
+    *         not complete.
     * @return Response to the request. Response is NULL if request packet is
     *         not complete.
     */
@@ -570,6 +581,11 @@ public:
      *
      * @param data
      *            Received data from the client.
+     * @param size
+     *            Size of the received data.
+     * @param reply
+     *            Response to the request. Response is NULL if request packet is
+     *         not complete.
      * @return Response to the request. Response is NULL if request packet is
      *         not complete.
      */
@@ -578,8 +594,15 @@ public:
     /**
      * Handles client request.
      *
+     * @param connectionInfo
+     *            Connection info.
      * @param data
      *            Received data from the client.
+     * @param size
+     *            Size of the received data.
+     * @param reply
+     *            Response to the request. Response is NULL if request packet is
+     *         not complete.
      * @return Response to the request. Response is NULL if request packet is
      *         not complete.
      */

--- a/development/include/GXDLMSSettings.h
+++ b/development/include/GXDLMSSettings.h
@@ -445,7 +445,7 @@ public:
     unsigned short GetCount();
 
     /**
-     * @param count
+     * @param value
      *            Long data count.
      */
     void SetCount(unsigned short value);
@@ -456,7 +456,7 @@ public:
     unsigned short GetIndex();
 
     /**
-     * @param index
+     * @param value
      *            Long data index
      */
     void SetIndex(unsigned short value);

--- a/development/include/GXDLMSValueEventArg.h
+++ b/development/include/GXDLMSValueEventArg.h
@@ -46,6 +46,9 @@ class CGXDLMSNotify;
 class CGXDLMSSettings;
 class CGXDLMSAssociationLogicalName;
 
+/**
+ * Value event arguments.
+*/
 class CGXDLMSValueEventArg {
     friend class CGXDLMSClient;
     friend class CGXDLMSServer;
@@ -253,7 +256,7 @@ public:
     DLMS_ERROR_CODE GetError();
 
     /**
-     * @param error
+     * @param value
      *            Occurred error.
      */
     void SetError(DLMS_ERROR_CODE value);

--- a/development/include/GXDate.h
+++ b/development/include/GXDate.h
@@ -61,12 +61,9 @@ public:
     /**
     * Constructor.
     *
-    * @param forvalue
+    * @param value
     *            Date value.
     */
-    /// <summary>
-    /// Constructor.
-    /// </summary>
     CGXDate(CGXDateTime &value): CGXDateTime(value.GetValue()) {
         SetSkip((DATETIME_SKIPS)(value.m_Skip | DATETIME_SKIPS_HOUR | DATETIME_SKIPS_MINUTE | DATETIME_SKIPS_SECOND |
                                  DATETIME_SKIPS_MS));

--- a/development/include/GXHelpers.h
+++ b/development/include/GXHelpers.h
@@ -43,6 +43,9 @@
 
 class CGXDLMSSettings;
 
+/**
+ * DLMS helper methods.
+*/
 class GXHelpers {
     /*
     * Convert char hex value to byte value.
@@ -182,7 +185,6 @@ public:
      *            Hex std::string.
      * @param buffer
      *            byte array.
-     * @return Occurred error.
      */
     static void HexToBytes(std::string &value, CGXByteBuffer &buffer);
 

--- a/development/include/GXSecure.h
+++ b/development/include/GXSecure.h
@@ -39,6 +39,9 @@
 #include "../include/GXBytebuffer.h"
 #include "../include/GXDLMSSettings.h"
 
+/**
+ * Secure channel.
+*/
 class CGXSecure {
 public:
     /**
@@ -46,6 +49,8 @@ public:
     *
     * @param authentication
     *            Used authentication.
+    * @param challenge
+    *            Generated challenge.
     * @return Generated challenge.
     */
     static int GenerateChallenge(DLMS_AUTHENTICATION authentication, CGXByteBuffer &challenge);
@@ -53,12 +58,18 @@ public:
     /**
     * Chipher text.
     *
-    * @param auth
-    *            Authentication level.
+    * @param settings
+    *            DLMS settings.
+    * @param cipher
+    *            Cipher.
+    * @param ic
+    *            Invocation counter.
     * @param data
     *            Text to chipher.
     * @param secret
     *            Secret.
+    * @param reply
+    *            Ciphered text.
     * @return Chiphered text.
     */
     static int Secure(

--- a/development/include/TranslatorSimpleTags.h
+++ b/development/include/TranslatorSimpleTags.h
@@ -187,7 +187,6 @@ public:
     /// <summary>
     /// Get ded tags.
     /// </summary>
-    /// <param name="type"></param>
     /// <param name="list"></param>
     static void GetDedTags(DLMS_TRANSLATOR_OUTPUT_TYPE /*type*/, std::map<unsigned long, std::string> &list) {
         list[DLMS_COMMAND_DED_INITIATE_REQUEST] = "ded_InitiateRequest";
@@ -204,7 +203,6 @@ public:
     /// <summary>
     /// Get translator tags.
     /// </summary>
-    /// <param name="type"></param>
     /// <param name="list"></param>
     static void GetTranslatorTags(DLMS_TRANSLATOR_OUTPUT_TYPE /*type*/, std::map<unsigned long, std::string> &list) {
         list[DLMS_TRANSLATOR_TAGS_WRAPPER] = "Wrapper";

--- a/development/src/GXAPDU.cpp
+++ b/development/src/GXAPDU.cpp
@@ -195,7 +195,6 @@ int SetConformanceToArray(unsigned int value, CGXByteBuffer &data) {
  *
  * @param settings
  *            DLMS settings.
- * @param cipher
  * @param data
  */
 int GetInitiateRequest(CGXDLMSSettings &settings, CGXCipher *, CGXByteBuffer &data) {
@@ -812,6 +811,8 @@ int CGXAPDU::ParseUserInformation(
  *            DLMS settings.
  * @param buff
  *            Received data.
+ * @param xml
+ *            XML translator.
  */
 int ParseApplicationContextName(
     CGXDLMSSettings &settings, CGXByteBuffer &buff

--- a/development/src/GXDLMS.cpp
+++ b/development/src/GXDLMS.cpp
@@ -184,15 +184,6 @@ int CGXDLMS::ReceiverReady(CGXDLMSSettings &settings, CGXReplyData &data, CGXCip
     return ret;
 }
 
-/**
-     * Split DLMS PDU to wrapper frames.
-     *
-     * @param settings
-     *            DLMS settings.
-     * @param data
-     *            Wrapped data.
-     * @return Wrapper frames.
-*/
 int CGXDLMS::GetWrapperFrame(
     CGXDLMSSettings &settings, DLMS_COMMAND command, CGXByteBuffer &data, CGXByteBuffer &reply
 ) {
@@ -605,6 +596,8 @@ void AddLLCBytes(CGXDLMSSettings *settings, CGXByteBuffer &data) {
      *            LN parameters.
      * @param reply
      *            Generated reply.
+     * @param ciphering
+     *            Is ciphering used.
      */
 void MultipleBlocks(CGXDLMSLNParameters &p, CGXByteBuffer &reply, unsigned char ciphering) {
     // Check is all data fit to one message if data is given.

--- a/development/src/GXDLMSClient.cpp
+++ b/development/src/GXDLMSClient.cpp
@@ -1420,36 +1420,10 @@ int CGXDLMSClient::Write(
     return ret;
 }
 
-/**
-    * Generate Method (Action) request.
-    *
-    * @param item
-    *            Method object short name or Logical Name.
-    * @param index
-    *            Method index.
-    * @param data
-    *            Method data.
-    * @param type
-    *            Data type.
-    * @return DLMS action message.
-    */
 int CGXDLMSClient::Method(CGXDLMSObject *item, int index, CGXDLMSVariant &data, std::vector<CGXByteBuffer> &reply) {
     return Method(item, index, data, data.vt, reply);
 }
 
-/**
-    * Generate Method (Action) request.
-    *
-    * @param item
-    *            Method object short name or Logical Name.
-    * @param index
-    *            Method index.
-    * @param data
-    *            Method data.
-    * @param type
-    *            Data type.
-    * @return DLMS action message.
-    */
 int CGXDLMSClient::Method(
     CGXDLMSObject *item, int index, CGXDLMSVariant &data, DLMS_DATA_TYPE dataType, std::vector<CGXByteBuffer> &reply
 ) {

--- a/development/src/GXDLMSLNCommandHandler.cpp
+++ b/development/src/GXDLMSLNCommandHandler.cpp
@@ -1086,13 +1086,6 @@ int CGXDLMSLNCommandHandler::MethodRequestNextBlock(
     return ret;
 }
 
-/**
- * Handle action request.
- *
- * @param reply
- *            Received data from the client.
- * @return Reply.
- */
 int CGXDLMSLNCommandHandler::HandleMethodRequest(
     CGXDLMSSettings &settings, CGXDLMSServer *server, CGXByteBuffer &data, CGXByteBuffer *replyData,
     CGXDLMSConnectionEventArgs *connectionInfo, CGXDLMSTranslatorStructure *xml, unsigned char cipheredCommand

--- a/development/src/GXDLMSProfileGeneric.cpp
+++ b/development/src/GXDLMSProfileGeneric.cpp
@@ -323,9 +323,6 @@ int CGXDLMSProfileGeneric::GetProfileGenericData(
     return GetData(settings, e, items, columns, reply);
 }
 
-/**
- Constructor.
-*/
 CGXDLMSProfileGeneric::CGXDLMSProfileGeneric(): CGXDLMSProfileGeneric("", 0) {
 }
 
@@ -340,31 +337,17 @@ CGXDLMSProfileGeneric::CGXDLMSProfileGeneric(std::string ln, unsigned short sn)
     m_SortMethod = DLMS_SORT_METHOD_FIFO;
 }
 
-/**
- Constructor.
-
- @param ln Logical Name of the object.
-*/
 CGXDLMSProfileGeneric::CGXDLMSProfileGeneric(std::string ln): CGXDLMSProfileGeneric(ln, 0) {
 }
 
-/**
- Data of profile generic.
-*/
 std::vector<std::vector<CGXDLMSVariant>> &CGXDLMSProfileGeneric::GetBuffer() {
     return m_Buffer;
 }
 
-/**
- Captured Objects.
-*/
 std::vector<std::pair<CGXDLMSObject *, CGXDLMSCaptureObject *>> &CGXDLMSProfileGeneric::GetCaptureObjects() {
     return m_CaptureObjects;
 }
 
-/**
- How often values are captured.
-*/
 int CGXDLMSProfileGeneric::GetCapturePeriod() {
     return m_CapturePeriod;
 }
@@ -373,9 +356,6 @@ void CGXDLMSProfileGeneric::SetCapturePeriod(int value) {
     m_CapturePeriod = value;
 }
 
-/**
- How columns are sorted.
-*/
 GX_SORT_METHOD CGXDLMSProfileGeneric::GetSortMethod() {
     return m_SortMethod;
 }
@@ -429,10 +409,6 @@ void CGXDLMSProfileGeneric::Reset() {
     m_EntriesInUse = 0;
 }
 
-/*
-* Copies the values of the objects to capture into the buffer by reading
-* capture objects.
-*/
 int CGXDLMSProfileGeneric::Capture(CGXDLMSServer *server) {
     std::vector<CGXDLMSVariant> values;
     int ret;

--- a/development/src/GXDLMSSettings.cpp
+++ b/development/src/GXDLMSSettings.cpp
@@ -437,7 +437,7 @@ unsigned short CGXDLMSSettings::GetCount() {
 }
 
 /**
- * @param count
+ * @param value
  *            Long data count.
  */
 void CGXDLMSSettings::SetCount(unsigned short value) {
@@ -452,7 +452,7 @@ unsigned short CGXDLMSSettings::GetIndex() {
 }
 
 /**
- * @param index
+ * @param value
  *            Long data index
  */
 void CGXDLMSSettings::SetIndex(unsigned short value) {

--- a/development/src/GXSecure.cpp
+++ b/development/src/GXSecure.cpp
@@ -139,17 +139,6 @@ int CGXSecure::DecryptAesKeyWrapping(CGXByteBuffer &data, CGXByteBuffer &kek, CG
     return 0;
 }
 
-/**
-    * Chipher text.
-    *
-    * @param auth
-    *            Authentication level.
-    * @param data
-    *            Text to chipher.
-    * @param secret
-    *            Secret.
-    * @return Chiphered text.
-    */
 int CGXSecure::Secure(
     CGXDLMSSettings &settings, CGXCipher *cipher, unsigned long ic, CGXByteBuffer &data, CGXByteBuffer &secret,
     CGXByteBuffer &reply


### PR DESCRIPTION
Adds Doxygen documentation blocks to classes in header files. Fixes all Doxygen warnings, including:
- Incorrect `@param` tags.
- `multiple documentation sections` warnings caused by duplicate comments in `.cpp` files.
- A typo in a Doxygen tag that caused a `no matching class member found` warning.